### PR TITLE
implement visualizing saved checkpoints for cartpole

### DIFF
--- a/ksim/env/toy/cartpole_env.py
+++ b/ksim/env/toy/cartpole_env.py
@@ -13,8 +13,13 @@ from ksim.env.base_env import BaseEnv, EnvState
 class CartPoleEnv(BaseEnv):
     """CartPole environment wrapper to match the BraxState interface."""
 
-    def __init__(self) -> None:
-        self.env = gym.make("CartPole-v1")
+    def __init__(self, render_mode: str | None = None) -> None:
+        """Initialize the CartPole environment.
+
+        Args:
+            render_mode: The render mode for the environment. Options: 'human', 'rgb_array', None
+        """
+        self.env = gym.make("CartPole-v1", render_mode=render_mode)
         self.observation_space = self.env.observation_space
         self.action_space = self.env.action_space
 

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -99,6 +99,9 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             return f"render_{time_string}"
         return f"render_{state.num_steps}_{time_string}"
 
+    @abstractmethod
+    def viz_environment(self) -> None: ...
+
     def run_environment(
         self,
         state: xax.State | None = None,
@@ -348,6 +351,9 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
 
             case "env":
                 self.run_environment()
+
+            case "viz":
+                self.viz_environment()
 
             case _:
                 raise ValueError(f"Invalid action: {self.config.action}. Should be one of `train` or `env`.")


### PR DESCRIPTION
I was initially gonna put this in run_environment, but realized that's not what it's meant for.

So I made a viz_environment function that lets see you see how a saved checkpoint is doing.

I can move stuff around if we don't want a simple viz_environment type thing to exist.