### PR TITLE
Add basic Tensorboard logging functionality to RL Task

### DIFF
--- a/ksim/env/builders/loggers.py
+++ b/ksim/env/builders/loggers.py
@@ -1,0 +1,116 @@
+"""Defines a standard interface for logging metrics."""
+
+from abc import ABC, abstractmethod
+from typing import Generic, NamedTuple, Optional, TypeVar
+
+import attrs
+import jax.numpy as jnp
+import xax
+from jaxtyping import PyTree
+
+from ksim.utils.data import BuilderData
+
+
+@attrs.define(frozen=True, kw_only=True)
+class LoggingData:
+    trajectory: Optional[NamedTuple] = None
+    update_metrics: dict[str, jnp.ndarray] = attrs.field(
+        factory=dict
+    )  # e.g., policy_loss, value_loss, entropy, total_loss
+    gradients: Optional[PyTree] = None
+    loss: Optional[float] = None
+    training_state: Optional[xax.State] = None
+
+
+@attrs.define(frozen=True, kw_only=True)
+class LogMetric(ABC):
+    @abstractmethod
+    def __call__(self, data: LoggingData) -> jnp.ndarray:
+        """Compute the log metric from trajectory data.
+
+        The data argument should include any fields necessary for computing
+        the metric.
+        """
+
+    def get_name(self) -> str:
+        """Returns a human-friendly name for the metric."""
+        return xax.camelcase_to_snakecase(self.__class__.__name__)
+
+
+T = TypeVar("T", bound=LogMetric)
+
+
+class LogMetricBuilder(ABC, Generic[T]):
+    @abstractmethod
+    def __call__(self, data: Optional[BuilderData] = None) -> T:
+        """Constructs and returns a log metric instance given some builder data."""
+
+
+@attrs.define(frozen=True, kw_only=True)
+class EpisodeLengthLog(LogMetric):
+    def __call__(self, data: LoggingData) -> jnp.ndarray:
+        """Computes the average episode length."""
+        trajectory = data.trajectory
+        return jnp.sum(~trajectory.done) / (jnp.sum(trajectory.done) + 1)
+
+
+class EpisodeLengthLogBuilder(LogMetricBuilder[EpisodeLengthLog]):
+    def __init__(self) -> None:
+        pass
+
+    def __call__(self, data: Optional[BuilderData] = None) -> EpisodeLengthLog:
+        return EpisodeLengthLog()
+
+
+class AverageRewardLog(LogMetric):
+    def __call__(self, data: LoggingData) -> jnp.ndarray:
+        """Computes the average reward per episode."""
+        trajectory = data.trajectory
+        total_reward = jnp.sum(trajectory.rewards)
+        episode_count = jnp.sum(trajectory.done) + 1  # +1 to avoid division by zero
+        return total_reward / episode_count
+
+
+class AverageRewardLogBuilder(LogMetricBuilder[AverageRewardLog]):
+    def __call__(self, data: Optional[BuilderData] = None) -> AverageRewardLog:
+        return AverageRewardLog()
+
+
+class PolicyLossLog(LogMetric):
+    def __call__(self, data: LoggingData) -> jnp.ndarray:
+        return data.update_metrics["policy_loss"]
+
+
+class PolicyLossLogBuilder(LogMetricBuilder[PolicyLossLog]):
+    def __call__(self, data: Optional[BuilderData] = None) -> PolicyLossLog:
+        return PolicyLossLog()
+
+
+class ValueLossLog(LogMetric):
+    def __call__(self, data: LoggingData) -> jnp.ndarray:
+        return data.update_metrics["value_loss"]
+
+
+class ValueLossLogBuilder(LogMetricBuilder[ValueLossLog]):
+    def __call__(self, data: Optional[BuilderData] = None) -> ValueLossLog:
+        return ValueLossLog()
+
+
+class EntropyLog(LogMetric):
+    def __call__(self, data: LoggingData) -> jnp.ndarray:
+        return data.update_metrics["entropy"]
+
+
+class EntropyLogBuilder(LogMetricBuilder[EntropyLog]):
+    def __call__(self, data: Optional[BuilderData] = None) -> EntropyLog:
+        return EntropyLog()
+
+
+class TotalLossLog(LogMetric):
+    def __call__(self, data: LoggingData) -> jnp.ndarray:
+        return data.update_metrics["total_loss"]
+
+
+class TotalLossLogBuilder(LogMetricBuilder[TotalLossLog]):
+    def __call__(self, data: Optional[BuilderData] = None) -> TotalLossLog:
+        return TotalLossLog()

--- a/ksim/env/builders/loggers.py
+++ b/ksim/env/builders/loggers.py
@@ -1,14 +1,12 @@
 """Defines a standard interface for logging metrics."""
 
 from abc import ABC, abstractmethod
-from typing import Generic, NamedTuple, TypeVar
+from typing import NamedTuple
 
 import attrs
 import jax.numpy as jnp
 import xax
 from jaxtyping import Array, PyTree
-
-from ksim.utils.data import BuilderData
 
 
 class TrajectoryData(NamedTuple):
@@ -30,9 +28,7 @@ class TrajectoryData(NamedTuple):
 @attrs.define(frozen=True, kw_only=True)
 class LoggingData:
     trajectory: TrajectoryData | None = None
-    update_metrics: dict[str, jnp.ndarray] = attrs.field(
-        factory=dict
-    )
+    update_metrics: dict[str, jnp.ndarray] = attrs.field(factory=dict)
     gradients: PyTree | None = None
     loss: float | None = None
     training_state: xax.State | None = None
@@ -52,6 +48,7 @@ class LogMetric(ABC):
         """Returns a human-friendly name for the metric."""
         return xax.camelcase_to_snakecase(self.__class__.__name__)
 
+
 @attrs.define(frozen=True, kw_only=True)
 class EpisodeLengthLog(LogMetric):
     def __call__(self, data: LoggingData) -> jnp.ndarray:
@@ -61,6 +58,7 @@ class EpisodeLengthLog(LogMetric):
         # Ensure we have at least one termination event.
         episode_count = jnp.sum(trajectory.done).clip(min=1)
         return jnp.sum(~trajectory.done) / episode_count
+
 
 @attrs.define(frozen=True, kw_only=True)
 class AverageRewardLog(LogMetric):

--- a/ksim/env/builders/loggers.py
+++ b/ksim/env/builders/loggers.py
@@ -1,7 +1,7 @@
 """Defines a standard interface for logging metrics."""
 
 from abc import ABC, abstractmethod
-from typing import Generic, NamedTuple, Optional, TypeVar
+from typing import Generic, NamedTuple, TypeVar
 
 import attrs
 import jax.numpy as jnp
@@ -29,13 +29,13 @@ class TrajectoryData(NamedTuple):
 
 @attrs.define(frozen=True, kw_only=True)
 class LoggingData:
-    trajectory: Optional[TrajectoryData] = None
+    trajectory: TrajectoryData | None = None
     update_metrics: dict[str, jnp.ndarray] = attrs.field(
         factory=dict
-    )  # e.g., policy_loss, value_loss, entropy, total_loss
-    gradients: Optional[PyTree] = None
-    loss: Optional[float] = None
-    training_state: Optional[xax.State] = None
+    )
+    gradients: PyTree | None = None
+    loss: float | None = None
+    training_state: xax.State | None = None
 
 
 @attrs.define(frozen=True, kw_only=True)
@@ -52,85 +52,33 @@ class LogMetric(ABC):
         """Returns a human-friendly name for the metric."""
         return xax.camelcase_to_snakecase(self.__class__.__name__)
 
-
-T = TypeVar("T", bound=LogMetric)
-
-
-class LogMetricBuilder(ABC, Generic[T]):
-    @abstractmethod
-    def __call__(self, data: Optional[BuilderData] = None) -> T:
-        """Constructs and returns a log metric instance given some builder data."""
-
-
 @attrs.define(frozen=True, kw_only=True)
 class EpisodeLengthLog(LogMetric):
     def __call__(self, data: LoggingData) -> jnp.ndarray:
-        """Computes the average episode length."""
         if data.trajectory is None:
             raise ValueError("Trajectory cannot be None for EpisodeLengthLog")
         trajectory = data.trajectory
-        return jnp.sum(~trajectory.done) / (jnp.sum(trajectory.done) + 1)
+        # Ensure we have at least one termination event.
+        episode_count = jnp.sum(trajectory.done).clip(min=1)
+        return jnp.sum(~trajectory.done) / episode_count
 
-
-class EpisodeLengthLogBuilder(LogMetricBuilder[EpisodeLengthLog]):
-    def __init__(self) -> None:
-        pass
-
-    def __call__(self, data: Optional[BuilderData] = None) -> EpisodeLengthLog:
-        return EpisodeLengthLog()
-
-
+@attrs.define(frozen=True, kw_only=True)
 class AverageRewardLog(LogMetric):
     def __call__(self, data: LoggingData) -> jnp.ndarray:
-        """Computes the average reward per episode."""
         if data.trajectory is None:
             raise ValueError("Trajectory cannot be None for AverageRewardLog")
         trajectory = data.trajectory
         total_reward = jnp.sum(trajectory.rewards)
-        episode_count = jnp.sum(trajectory.done) + 1  # +1 to avoid division by zero
+        episode_count = jnp.sum(trajectory.done).clip(min=1)
         return total_reward / episode_count
 
 
-class AverageRewardLogBuilder(LogMetricBuilder[AverageRewardLog]):
-    def __call__(self, data: Optional[BuilderData] = None) -> AverageRewardLog:
-        return AverageRewardLog()
+@attrs.define(frozen=True)
+class ModelUpdateLog(LogMetric):
+    name: str = attrs.field()
 
-
-class PolicyLossLog(LogMetric):
     def __call__(self, data: LoggingData) -> jnp.ndarray:
-        return data.update_metrics["policy_loss"]
+        return data.update_metrics[self.name]
 
-
-class PolicyLossLogBuilder(LogMetricBuilder[PolicyLossLog]):
-    def __call__(self, data: Optional[BuilderData] = None) -> PolicyLossLog:
-        return PolicyLossLog()
-
-
-class ValueLossLog(LogMetric):
-    def __call__(self, data: LoggingData) -> jnp.ndarray:
-        return data.update_metrics["value_loss"]
-
-
-class ValueLossLogBuilder(LogMetricBuilder[ValueLossLog]):
-    def __call__(self, data: Optional[BuilderData] = None) -> ValueLossLog:
-        return ValueLossLog()
-
-
-class EntropyLog(LogMetric):
-    def __call__(self, data: LoggingData) -> jnp.ndarray:
-        return data.update_metrics["entropy"]
-
-
-class EntropyLogBuilder(LogMetricBuilder[EntropyLog]):
-    def __call__(self, data: Optional[BuilderData] = None) -> EntropyLog:
-        return EntropyLog()
-
-
-class TotalLossLog(LogMetric):
-    def __call__(self, data: LoggingData) -> jnp.ndarray:
-        return data.update_metrics["total_loss"]
-
-
-class TotalLossLogBuilder(LogMetricBuilder[TotalLossLog]):
-    def __call__(self, data: Optional[BuilderData] = None) -> TotalLossLog:
-        return TotalLossLog()
+    def get_name(self) -> str:
+        return self.name

--- a/ksim/env/builders/loggers.py
+++ b/ksim/env/builders/loggers.py
@@ -1,33 +1,18 @@
 """Defines a standard interface for logging metrics."""
 
 from abc import ABC, abstractmethod
-from typing import NamedTuple
 
 import attrs
 import jax.numpy as jnp
 import xax
-from jaxtyping import Array, PyTree
+from jaxtyping import PyTree
 
-
-class TrajectoryData(NamedTuple):
-    """Simple trajectory data structure for logging.
-
-    TODO: This class should really be PPOBatch, but that leads to circular imports.
-    So we should have a base "Batch" type in a seperate file that both PPO and
-    logging can import from.
-    """
-
-    observations: PyTree
-    next_observations: PyTree
-    actions: Array
-    rewards: Array
-    done: Array
-    action_log_probs: Array
+from ksim.types import PPOBatch
 
 
 @attrs.define(frozen=True, kw_only=True)
 class LoggingData:
-    trajectory: TrajectoryData | None = None
+    trajectory: PPOBatch | None = None
     update_metrics: dict[str, jnp.ndarray] = attrs.field(factory=dict)
     gradients: PyTree | None = None
     loss: float | None = None

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -156,7 +156,7 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
         model: ActorCriticModel,
         params: PyTree,
         batch: PPOBatch,
-    ) -> tuple[Array, dict[str, float]]:
+    ) -> tuple[Array, dict[str, Array]]:
         """Compute the PPO loss (required by XAX).
 
         Args:
@@ -165,7 +165,7 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
             batch: The mini-batch containing trajectories.
 
         Returns:
-            A tuple of (loss, metrics).
+            A tuple of (loss, metrics), where metrics contains JAX arrays for various losses.
         """
         # get the log probs of the current model
         predictions = self.apply_actor(model, params, batch.observations)
@@ -240,10 +240,10 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
         model: ActorCriticModel,
         params: PyTree,
         batch: PPOBatch,
-    ) -> tuple[Array, dict[str, float], PyTree]:
+    ) -> tuple[Array, dict[str, Array], PyTree]:
         """Jitted version of value_and_grad computation."""
 
-        def loss_fn(p: PyTree) -> tuple[Array, dict[str, float]]:
+        def loss_fn(p: PyTree) -> tuple[Array, dict[str, Array]]:
             loss, metrics = self.compute_loss(model, p, batch)
             return loss, metrics
 

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -14,7 +14,7 @@ from jaxtyping import Array, PRNGKeyArray, PyTree
 from ksim.env.base_env import BaseEnv, EnvState
 from ksim.model.formulations import ActorCriticModel
 from ksim.task.rl import RLConfig, RLTask
-from ksim.types import ModelObs, ModelOut
+from ksim.types import ModelObs, ModelOut, PPOBatch
 
 
 @jax.tree_util.register_dataclass
@@ -43,17 +43,6 @@ class PPOConfig(RLConfig):
     schedule: str = xax.field(value="adaptive", help="Learning rate schedule 'fixed' | 'adaptive'")
     desired_kl: float = xax.field(value=0.01, help="Desired KL divergence for adaptive LR.")
     max_grad_norm: float = xax.field(value=1.0, help="Maximum gradient norm for clipping.")
-
-
-class PPOBatch(NamedTuple):
-    """A batch of PPO training data."""
-
-    observations: PyTree
-    next_observations: PyTree
-    actions: Array
-    rewards: Array
-    done: Array
-    action_log_probs: Array
 
 
 Config = TypeVar("Config", bound=PPOConfig)

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -130,7 +130,7 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
         params: PyTree,
         optimizer: optax.GradientTransformation,
         opt_state: optax.OptState,
-        batch: NamedTuple,
+        batch: PPOBatch,
     ) -> tuple[PyTree, optax.OptState, Array, dict]:
         """Update the model parameters."""
         loss_val, metrics, grads = self._jitted_value_and_grad(model, params, batch)
@@ -251,7 +251,7 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
         model: ActorCriticModel,
         params: PyTree,
         batch: PPOBatch,
-    ) -> tuple[Array, PyTree]:
+    ) -> tuple[Array, Dict[str, Array], PyTree]:
         """Jitted version of value_and_grad computation."""
 
         def loss_fn(p: PyTree) -> tuple[Array, dict[str, Array]]:

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -91,7 +91,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
 
         self.max_trajectory_steps = round(self.config.max_trajectory_seconds / self.config.ctrl_dt)
         self.curr_logging_data = LoggingData()
-        self.loggers = [
+        self.log_items = [
             EpisodeLengthLog(),
             AverageRewardLog(),
             ModelUpdateLog("policy_loss"), # name should be the key in update_metrics
@@ -309,7 +309,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             # Logs the trajectory statistics.
             with self.step_context("write_logs"):
                 training_state.raw_phase = "train"
-                for log_item in self.loggers:
+                for log_item in self.log_items:
                     self.logger.log_scalar(
                         log_item.get_name(), lambda logger=log_item: logger(self.curr_logging_data), namespace="📉"
                     )

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -24,9 +24,9 @@ from omegaconf import MISSING
 
 from ksim.env.base_env import BaseEnv, EnvState
 from ksim.env.builders.loggers import (
-    LoggingData,
-    EpisodeLengthLog,
     AverageRewardLog,
+    EpisodeLengthLog,
+    LoggingData,
     ModelUpdateLog,
 )
 from ksim.env.mjx.mjx_env import (
@@ -94,7 +94,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         self.log_items = [
             EpisodeLengthLog(),
             AverageRewardLog(),
-            ModelUpdateLog("policy_loss"), # name should be the key in update_metrics
+            ModelUpdateLog("policy_loss"),  # name should be the key in update_metrics
             ModelUpdateLog("value_loss"),
             ModelUpdateLog("entropy"),
             ModelUpdateLog("total_loss"),

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -133,7 +133,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         optimizer: optax.GradientTransformation,
         opt_state: optax.OptState,
         batch: NamedTuple,
-    ) -> tuple[PyTree, optax.OptState, Array, dict]: ...
+    ) -> tuple[PyTree, optax.OptState, Array, dict[str, Array]]: ...
 
     ##############
     # Properties #
@@ -311,7 +311,9 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                 training_state.raw_phase = "train"
                 for log_item in self.log_items:
                     self.logger.log_scalar(
-                        log_item.get_name(), lambda logger=log_item: logger(self.curr_logging_data), namespace="📉"
+                        log_item.get_name(),
+                        lambda logger=log_item: logger(self.curr_logging_data),
+                        namespace="📉",
                     )
                 self.logger.write(training_state)
                 training_state.num_steps += 1
@@ -361,7 +363,8 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             except xax.TrainingFinishedError:
                 if xax.is_master():
                     msg = (
-                        f"Finished training after {training_state.num_steps} steps {training_state.num_samples} samples"
+                        f"Finished training after {training_state.num_steps}"
+                        f"steps and {training_state.num_samples} samples"
                     )
                     xax.show_info(msg, important=True)
                 self.save_checkpoint(model, optimizer, opt_state, training_state)

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -305,7 +305,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                 trajectory=trajectories,
                 update_metrics=metrics,
                 gradients=None,
-                loss=loss_val,
+                loss=float(loss_val),
                 training_state=training_state,
             )
 

--- a/ksim/types.py
+++ b/ksim/types.py
@@ -1,6 +1,19 @@
 """Includes all major typing."""
 
+from typing import NamedTuple
+
 from jaxtyping import Array, PyTree
 
 ModelObs = Array | PyTree[Array]
 ModelOut = Array | PyTree[Array]
+
+
+class PPOBatch(NamedTuple):
+    """Batch data structure for PPO training and logging."""
+
+    observations: PyTree
+    next_observations: PyTree
+    actions: Array
+    rewards: Array
+    done: Array
+    action_log_probs: Array


### PR DESCRIPTION
I am using the builder pattern so for example the logic to compute episode length can be in the episode length log class, this helps keep rl.py clean.

Each logging class expects a LoggingData class which contains trajectories, model update metrics, etc, basically whatever we might want to log from 

I am also using the logging infra already implemented in xax wherever possible. 

I get circular import issues with PPO batch when I try to import it, we should probably have a base RLBatch or MLBatch class that rl.py, loggers.py and ppo.py can all import from.

