### PR TITLE
rotate zbot so that x is forward

### DIFF
--- a/examples/zbot2/robot.xml
+++ b/examples/zbot2/robot.xml
@@ -51,7 +51,7 @@
   </asset>
 
   <worldbody>
-    <body name="floating_base_link" pos="0.00000000 0.00000000 0.42" childclass="robot">
+    <body name="floating_base_link" pos="0.00000000 0.00000000 0.42181800" quat="0.7071 0 0 0.7071" childclass="robot">
       <freejoint name="floating_base" />
       <geom name="floating_base_link_visual" material="floating_base_link_material" type="sphere" size="0.01" class="visual" />
       <body name="Z_BOT2_MASTER_BODY_SKELETON">


### PR DESCRIPTION
This way it matches default humanoid, and our official diagram

Diagram: https://docs.kscale.dev/docs/robot-overview
![image](https://github.com/user-attachments/assets/a4d92bfc-d8c6-44b0-bba7-7c7c5b255fd5)

What this PR will make it look like in Mujoco:
![image](https://github.com/user-attachments/assets/44372f9c-2212-411c-b967-d0a4aa589f2a)

What default humanoid currently looks like (this PR will make zbot match it):
![image](https://github.com/user-attachments/assets/9838f6a1-7176-492a-afd6-6d60ceb67e70)

