### PR TITLE
rotate kbot2 so x is forward

### DIFF
--- a/examples/kbot2/robot.xml
+++ b/examples/kbot2/robot.xml
@@ -66,7 +66,7 @@
   </asset>
 
   <worldbody>
-    <body name="floating_base_link" pos="0.00000000 0.00000000 0.80024304" childclass="robot">
+    <body name="floating_base_link" pos="0.00000000 0.00000000 0.80024304" quat="0.7071 0 0 0.7071" childclass="robot">
       <freejoint name="floating_base" />
       <geom name="floating_base_link_visual" quat="0.0007963267107332633 0.0 0.0 0.9999996829318346" material="floating_base_link_material" type="sphere" size="0.01" class="visual" />
       <body name="KB_B_102B_TORSO_BOTTOM" quat="0.0007963267107332633 0.0 0.0 0.9999996829318346">


### PR DESCRIPTION
This PR makes it looks like this, where x is facing forward
![image](https://github.com/user-attachments/assets/ac7144f9-b490-4103-a94d-7f606c1e8620)
This way it matches the diagram :
![image](https://github.com/user-attachments/assets/6c7fa8a6-e326-4085-87f4-09f6e0612fb2)
https://docs.kscale.dev/docs/hardware-overview