### PR TITLE
combine trajectory unrolling and model update into the same jitted fn

### DIFF
--- a/examples/default_humanoid/walking.py
+++ b/examples/default_humanoid/walking.py
@@ -480,7 +480,6 @@ if __name__ == "__main__":
             ctrl_dt=0.02,
             max_action_latency=0.0,
             min_action_latency=0.0,
-            save_every_n_steps=50,
             rollout_length_seconds=21.0,
             eval_rollout_length_seconds=4.0,
             # PPO parameters

--- a/ksim/env/data.py
+++ b/ksim/env/data.py
@@ -1,7 +1,7 @@
 """Base Types for Environments."""
 
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import Mapping, TypeAlias
 
 import jax
 import mujoco
@@ -53,3 +53,11 @@ class Histogram:
     sum: Array
     sum_squares: Array
     mean: Array
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class Metrics:
+    train: Mapping[str, Array | Histogram]
+    reward: Mapping[str, Array | Histogram]
+    termination: Mapping[str, Array | Histogram]

--- a/ksim/env/data.py
+++ b/ksim/env/data.py
@@ -52,3 +52,4 @@ class Histogram:
     max: Array
     sum: Array
     sum_squares: Array
+    mean: Array

--- a/ksim/env/data.py
+++ b/ksim/env/data.py
@@ -41,3 +41,14 @@ class Trajectory:
 class Rewards:
     total: Array
     components: FrozenDict[str, Array]
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class Histogram:
+    counts: Array
+    limits: Array
+    min: Array
+    max: Array
+    sum: Array
+    sum_squares: Array

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -376,6 +376,7 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
             "value": values_t.mean(),
             "value_targets": value_targets_t.mean(),
             "advantages": advantages_t.mean(),
+            **{key: value.mean() for key, value in rewards.components.items()},
         }
 
     @xax.jit(static_argnames=["self", "model_static"])

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -370,7 +370,6 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
         """
         return {
             "loss": loss_t.mean(),
-            "reward": rewards.total.mean(),
             "log_probs": log_probs_tn.mean(0).flatten(),
             "entropy": entropy_tn.mean(0).flatten(),
             "value": values_t.mean(),

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -376,7 +376,6 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
             "value": values_t.mean(),
             "value_targets": value_targets_t.mean(),
             "advantages": advantages_t.mean(),
-            **{key: value.mean() for key, value in rewards.components.items()},
         }
 
     @xax.jit(static_argnames=["self", "model_static"])

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -388,6 +388,7 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
             A dictionary of metrics to be logged.
         """
         slen = (~trajectories.done).sum(dtype=loss_t.dtype) + 1e-6
+
         return {
             "loss": self.get_histogram(loss_t.sum() / slen),
             "log_probs": self.get_histogram(log_probs_tn.sum(0).flatten() / slen),

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -906,7 +906,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         opt_state: optax.OptState,
         engine: PhysicsEngine,
         engine_constants: EngineConstants,
-    ) -> tuple[PyTree, optax.OptState, FrozenDict[str, Array]]:
+    ) -> tuple[PyTree, optax.OptState, FrozenDict[str, Array | Histogram]]:
         def single_step_fn(
             carry: tuple[PyTree, optax.OptState, PRNGKeyArray],
             _: None,

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -1153,7 +1153,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                         render_elevation=self.config.render_elevation,
                         render_lookat=self.config.render_lookat,
                     )
-                    for step_id in iterator:
+                    for _ in iterator:
                         # We need to manually sync the data back and forth between
                         # the viewer and the engine, because the resetting the
                         # environment creates a new data object rather than

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -864,20 +864,11 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             as a scalar, otherwise it is logged as a histogram.
         """
 
-    @xax.jit(
-        static_argnames=[
-            "self",
-            "mjx_model",
-            "model_static",
-            "optimizer",
-            "engine",
-            "engine_constants",
-        ]
-    )
+    @xax.jit(static_argnames=["self", "model_static", "optimizer", "engine", "engine_constants"])
     def _rl_train_loop_step(
         self,
         rng: PRNGKeyArray,
-        mjx_model: mjx.Model,
+        physics_model: PhysicsModel,
         model_arr: PyTree,
         model_static: PyTree,
         optimizer: optax.GradientTransformation,
@@ -902,7 +893,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         # Rolls out a new trajectory.
         trajectories, rewards = self._vmapped_unroll(
             rng=rollout_rng,
-            physics_model=mjx_model,
+            physics_model=physics_model,
             model_arr=model_arr,
             model_static=model_static,
             engine=engine,
@@ -1004,7 +995,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                 prev_trajectories, prev_rewards = prev_trajectory
                 (model_arr, opt_state, train_metrics), (trajectories, rewards) = self._rl_train_loop_step(
                     rng=update_rng,
-                    mjx_model=mjx_model,
+                    physics_model=mjx_model,
                     model_arr=model_arr,
                     model_static=model_static,
                     optimizer=optimizer,

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -216,6 +216,10 @@ class RLConfig(xax.Config):
         value=1,
         help="The number of epochs between logging steps.",
     )
+    valid_every_n_seconds: float | None = xax.field(
+        value=60.0,
+        help="Run validation every N seconds",
+    )
 
     # Training parameters.
     num_envs: int = xax.field(

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -1029,7 +1029,8 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                 trajectory = jax.tree.map(lambda arr: arr[0], trajectories)
                 reward = jax.tree.map(lambda arr: arr[0], rewards)
 
-                self.log_single_trajectory(trajectory, commands, reward, mj_model)
+                if state.num_valid_steps % self.config.log_single_traj_every_n_valid_steps == 0:
+                    self.log_single_trajectory(trajectory, commands, reward, mj_model)
                 self.log_trajectory_stats(trajectories, rewards)
                 self.log_state_timers(state)
                 self.write_logs(state)

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -1021,27 +1021,25 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             state = self.on_step_start(state)
 
             # Optimizes the model on that trajectory.
-            with self.step_context("update"):
-                rng, update_rng = jax.random.split(rng)
-                model_arr, opt_state, train_metrics = self._rl_train_loop_step(
-                    rng=update_rng,
-                    physics_model=mjx_model,
-                    model_arr=model_arr,
-                    model_static=model_static,
-                    optimizer=optimizer,
-                    opt_state=opt_state,
-                    engine=engine,
-                    engine_constants=engine_constants,
-                )
+            rng, update_rng = jax.random.split(rng)
+            model_arr, opt_state, train_metrics = self._rl_train_loop_step(
+                rng=update_rng,
+                physics_model=mjx_model,
+                model_arr=model_arr,
+                model_static=model_static,
+                optimizer=optimizer,
+                opt_state=opt_state,
+                engine=engine,
+                engine_constants=engine_constants,
+            )
 
             state.raw_phase = "train"
             state.num_steps += self.config.epochs_per_log_step
             state.num_samples += self.rollout_length_steps * self.config.num_envs * self.config.epochs_per_log_step
 
-            with self.step_context("log"):
-                self.log_train_metrics(train_metrics)
-                self.log_state_timers(state)
-                self.write_logs(state)
+            self.log_train_metrics(train_metrics)
+            self.log_state_timers(state)
+            self.write_logs(state)
 
             state = self.on_step_end(state)
 

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -35,7 +35,7 @@ from PIL import Image, ImageDraw
 
 from ksim.actuators import Actuators
 from ksim.commands import Command
-from ksim.env.data import Histogram, PhysicsModel, PhysicsState, Rewards, Trajectory
+from ksim.env.data import Histogram, Metrics, PhysicsModel, PhysicsState, Rewards, Trajectory
 from ksim.env.engine import (
     EngineConstants,
     EngineVariables,
@@ -188,34 +188,6 @@ class RLConfig(xax.Config):
     )
 
     # Logging parameters.
-    log_qpos_qvel: bool = xax.field(
-        value=True,
-        help="If true, log qpos and qvel histograms.",
-    )
-    log_reward: bool = xax.field(
-        value=True,
-        help="If true, log reward histograms.",
-    )
-    log_trajectory_length: bool = xax.field(
-        value=True,
-        help="If true, log trajectory length histograms.",
-    )
-    log_actions: bool = xax.field(
-        value=True,
-        help="If true, log action histograms.",
-    )
-    log_observations: bool = xax.field(
-        value=True,
-        help="If true, log observation histograms.",
-    )
-    log_commands: bool = xax.field(
-        value=True,
-        help="If true, log command histograms.",
-    )
-    log_terminations: bool = xax.field(
-        value=True,
-        help="If true, log termination histograms.",
-    )
     log_train_metrics: bool = xax.field(
         value=True,
         help="If true, log train metrics.",
@@ -602,72 +574,33 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         else:
             self.run_training()
 
-    def log_trajectory_stats(self, trajectories: Trajectory, rewards: Rewards) -> None:
-        """Log action statistics from the trajectory or trajectories.
-
-        Args:
-            trajectories: The trajectories to log the action statistics for.
-            rewards: The rewards to log the statistics for.
-        """
-        if self.config.log_reward:
-            for rew_name, rew_arr in rewards.components.items():
-                self.logger.log_histogram(key=rew_name, value=rew_arr, namespace="🎁 reward histograms")
-                self.logger.log_scalar(key=rew_name, value=rew_arr.mean(), namespace="🎁 reward")
-            self.logger.log_histogram(key="total", value=rewards.total, namespace="🎁 reward histograms")
-            self.logger.log_scalar(key="total", value=rewards.total.mean(), namespace="🎁 reward")
-
-        if self.config.log_trajectory_length:
-            num_terms = trajectories.done.sum(-1, dtype=trajectories.action.dtype) + 1
-            traj_lens = (trajectories.done.shape[-1] / num_terms) * self.config.ctrl_dt
-            self.logger.log_histogram(key="traj_len_seconds", value=traj_lens, namespace="💀 termination histograms")
-            self.logger.log_scalar(key="traj_len_seconds", value=traj_lens.mean(), namespace="💀 termination")
-
-        if self.config.log_actions:
-            self.logger.log_histogram(key="action", value=trajectories.action, namespace="🏃 action histograms")
-
-        if self.config.log_observations:
-            for obs_key, obs_value in trajectories.obs.items():
-                self.logger.log_histogram(key=obs_key, value=obs_value, namespace="👀 observation histograms")
-
-        if self.config.log_commands:
-            for cmd_key, cmd_value in trajectories.command.items():
-                self.logger.log_histogram(key=cmd_key, value=cmd_value, namespace="🕹️ command histograms")
-
-        if self.config.log_terminations:
-            num_episodes = jnp.sum(trajectories.done).clip(min=1)
-            for term_name, term_value in trajectories.termination_components.items():
-                self.logger.log_scalar(
-                    key=term_name,
-                    value=term_value.sum() / num_episodes,
-                    namespace="💀 termination",
-                )
-
-        if self.config.log_qpos_qvel:
-            self.logger.log_histogram(key="qpos", value=trajectories.qpos[..., 7:], namespace="🔩 state histograms")
-            self.logger.log_histogram(key="qvel", value=trajectories.qvel[..., 6:], namespace="🔩 state histograms")
-
-    def log_train_metrics(self, train_metrics: FrozenDict[str, Array | Histogram]) -> None:
+    def log_train_metrics(self, metrics: Metrics) -> None:
         """Logs the train metrics.
 
         Args:
-            train_metrics: The train metrics to log.
+            metrics: The metrics to log.
         """
         if self.config.log_train_metrics:
-            for key, value in train_metrics.items():
-                if isinstance(value, Histogram):
-                    self.logger.log_histogram_raw(
-                        key,
-                        counts=value.counts,
-                        limits=value.limits,
-                        minv=value.min,
-                        maxv=value.max,
-                        sumv=value.sum,
-                        sum_squaresv=value.sum_squares,
-                        namespace="➡️ train histograms",
-                    )
-                    self.logger.log_scalar(key, value.mean, namespace="➡️ train")
-                else:
-                    self.logger.log_scalar(key, value.mean(), namespace="➡️ train")
+            for namespace, metric in (
+                ("🚂 train", metrics.train),
+                ("🎁 reward", metrics.reward),
+                ("💀 termination", metrics.termination),
+            ):
+                for key, value in metric.items():
+                    if isinstance(value, Histogram):
+                        self.logger.log_histogram_raw(
+                            key,
+                            counts=value.counts,
+                            limits=value.limits,
+                            minv=value.min,
+                            maxv=value.max,
+                            sumv=value.sum,
+                            sum_squaresv=value.sum_squares,
+                            namespace=f"{namespace} histograms",
+                        )
+                        self.logger.log_scalar(key, value.mean, namespace=namespace)
+                    else:
+                        self.logger.log_scalar(key, value.mean(), namespace=namespace)
 
     def render_trajectory_video(
         self,
@@ -911,6 +844,32 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             mean=arr.mean(),
         )
 
+    def get_reward_metrics(self, trajectories: Trajectory, rewards: Rewards) -> dict[str, Array]:
+        """Gets the reward metrics.
+
+        Args:
+            trajectories: The trajectories to get the reward metrics for.
+            rewards: The rewards to get the metrics for.
+        """
+        return {
+            "total": rewards.total,
+            **{key: value for key, value in rewards.components.items()},
+        }
+
+    def get_termination_metrics(self, trajectories: Trajectory) -> dict[str, Array]:
+        """Gets the termination metrics.
+
+        Args:
+            trajectories: The trajectories to get the termination metrics for.
+        """
+        num_terms = trajectories.done.sum(-1, dtype=trajectories.action.dtype) + 1
+        traj_lens = (trajectories.done.shape[-1] / num_terms) * self.config.ctrl_dt
+
+        return {
+            "episode_length": traj_lens.mean(),
+            **{key: (value / num_terms[:, None]).mean() for key, value in trajectories.termination_components.items()},
+        }
+
     @xax.jit(static_argnames=["self", "model_static", "optimizer", "engine", "engine_constants"])
     def _rl_train_loop_step(
         self,
@@ -922,14 +881,11 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         opt_state: optax.OptState,
         engine: PhysicsEngine,
         engine_constants: EngineConstants,
-    ) -> tuple[PyTree, optax.OptState, FrozenDict[str, Array | Histogram]]:
+    ) -> tuple[PyTree, optax.OptState, Metrics]:
         def single_step_fn(
             carry: tuple[PyTree, optax.OptState],
             rng: PRNGKeyArray,
-        ) -> tuple[
-            tuple[PyTree, optax.OptState],
-            tuple[FrozenDict[str, Array]],
-        ]:
+        ) -> tuple[tuple[PyTree, optax.OptState], Metrics]:
             model_arr, opt_state = carry
             rng, update_rng, rollout_rng = jax.random.split(rng, 3)
 
@@ -956,21 +912,24 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                 rng=update_rng,
             )
 
-            return (model_arr, opt_state), (train_metrics,)
+            metrics = Metrics(
+                train=train_metrics,
+                reward=FrozenDict(self.get_reward_metrics(trajectories, rewards)),
+                termination=FrozenDict(self.get_termination_metrics(trajectories)),
+            )
 
-        ((model_arr, opt_state), (train_metrics,)) = jax.lax.scan(
+            return (model_arr, opt_state), metrics
+
+        ((model_arr, opt_state), metrics) = jax.lax.scan(
             single_step_fn,
             (model_arr, opt_state),
             jax.random.split(rng, self.config.epochs_per_log_step),
         )
 
         # Convert any array with more than one element to a histogram.
-        train_metrics = jax.tree.map(
-            lambda x: self.get_histogram(x) if isinstance(x, Array) and x.size > 1 else x,
-            train_metrics,
-        )
+        metrics = jax.tree.map(lambda x: self.get_histogram(x) if isinstance(x, Array) and x.size > 1 else x, metrics)
 
-        return model_arr, opt_state, train_metrics
+        return model_arr, opt_state, metrics
 
     def rl_train_loop(
         self,
@@ -1031,7 +990,6 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
 
                 if state.num_valid_steps % self.config.log_single_traj_every_n_valid_steps == 0:
                     self.log_single_trajectory(trajectory, commands, reward, mj_model)
-                self.log_trajectory_stats(trajectories, rewards)
                 self.log_state_timers(state)
                 self.write_logs(state)
 
@@ -1039,7 +997,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
 
             # Optimizes the model on that trajectory.
             rng, update_rng = jax.random.split(rng)
-            model_arr, opt_state, train_metrics = self._rl_train_loop_step(
+            model_arr, opt_state, metrics = self._rl_train_loop_step(
                 rng=update_rng,
                 physics_model=mjx_model,
                 model_arr=model_arr,
@@ -1054,7 +1012,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             state.num_steps += self.config.epochs_per_log_step
             state.num_samples += self.rollout_length_steps * self.config.num_envs * self.config.epochs_per_log_step
 
-            self.log_train_metrics(train_metrics)
+            self.log_train_metrics(metrics)
             self.log_state_timers(state)
             self.write_logs(state)
 

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -216,10 +216,6 @@ class RLConfig(xax.Config):
         value=1,
         help="The number of epochs between logging steps.",
     )
-    valid_every_n_seconds: float | None = xax.field(
-        value=60.0,
-        help="Run validation every N seconds",
-    )
 
     # Training parameters.
     num_envs: int = xax.field(


### PR DESCRIPTION
On Mac Pro with command

```bash
python -m examples.default_humanoid.walking \
  num_envs=8 \
  num_batches=2 \
  rollout_length_seconds=10.0
```

Before change:

<img width="263" alt="Screenshot 2025-03-23 at 11 11 17 PM" src="https://github.com/user-attachments/assets/1dc7bb49-ad9b-4e54-944c-2d1f3a2d2793" />

After change:

<img width="167" alt="image" src="https://github.com/user-attachments/assets/d24ffe5b-e7f8-4624-b6ad-3afd923a6717" />