### PR TITLE
randomize once

### DIFF
--- a/examples/default_humanoid/walking.py
+++ b/examples/default_humanoid/walking.py
@@ -476,7 +476,7 @@ if __name__ == "__main__":
     # python -m examples.default_humanoid.walking run_environment=True
     HumanoidWalkingTask.launch(
         HumanoidWalkingTaskConfig(
-            num_envs=4096,
+            num_envs=2048,
             num_batches=64,
             num_passes=8,
             # Simulation parameters.

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -1139,7 +1139,6 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             # Gets initial variables.
             rng, carry_rng, cmd_rng = jax.random.split(rng, 3)
             initial_carry = self.get_initial_carry(carry_rng)
-            rng, cmd_rng = jax.random.split(rng)
             initial_commands = get_initial_commands(cmd_rng, command_generators=commands)
 
             # Resets the physics state.


### PR DESCRIPTION
## Change Description

This implements the "infinite event horizon" idea from [here](https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/):

<img width="757" alt="image" src="https://github.com/user-attachments/assets/5d6dddc3-c854-4381-8081-f84c92e840a8" />

Replaces:

<img width="751" alt="image" src="https://github.com/user-attachments/assets/c4970711-9f49-4880-80c7-0b33f877e536" />

We can decide if it is worth merging or not after doing some more thorough experiments.

## On MacOS

Before change:

![image](https://github.com/user-attachments/assets/e3c3acd9-d56b-43ea-a1ad-19a930ca5dfb)

After change:

<img width="227" alt="image" src="https://github.com/user-attachments/assets/d6886db8-4999-438a-862c-6cf3e21ed987" />

## On GPU

Noticed that JIT'ing everything causes OOMs for 4096 environments.

`run_5` is pre-change, `run_3` is post-change

<img width="729" alt="image" src="https://github.com/user-attachments/assets/a06c2191-8773-432b-a644-010a400db9a7" />

<img width="727" alt="image" src="https://github.com/user-attachments/assets/233576f2-d5d1-490c-bda9-f06f506f5aa5" />
