### PR TITLE
Faster Validation

### DIFF
--- a/examples/default_humanoid/jumping_lstm.py
+++ b/examples/default_humanoid/jumping_lstm.py
@@ -80,7 +80,6 @@ if __name__ == "__main__":
             max_action_latency=0.0,
             min_action_latency=0.0,
             rollout_length_seconds=10.0,  # This needs to be shorter because of memory constraints.
-            eval_rollout_length_seconds=4.0,
             # PPO parameters
             gamma=0.97,
             lam=0.95,

--- a/examples/default_humanoid/walking.py
+++ b/examples/default_humanoid/walking.py
@@ -484,7 +484,6 @@ if __name__ == "__main__":
             max_action_latency=0.0,
             min_action_latency=0.0,
             rollout_length_seconds=21.0,
-            eval_rollout_length_seconds=4.0,
             # PPO parameters
             gamma=0.97,
             lam=0.95,

--- a/examples/default_humanoid/walking_lstm.py
+++ b/examples/default_humanoid/walking_lstm.py
@@ -362,7 +362,6 @@ if __name__ == "__main__":
             max_action_latency=0.0,
             min_action_latency=0.0,
             rollout_length_seconds=10.0,  # This needs to be shorter because of memory constraints.
-            eval_rollout_length_seconds=4.0,
             # PPO parameters
             gamma=0.97,
             lam=0.95,

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -250,10 +250,6 @@ class RLConfig(xax.Config):
         value=MISSING,
         help="The number of seconds to rollout each environment during training.",
     )
-    eval_rollout_length_seconds: float = xax.field(
-        value=II("rollout_length_seconds"),
-        help="The number of seconds to rollout the model for evaluation.",
-    )
 
     # Rendering parameters.
     max_values_per_plot: int = xax.field(
@@ -499,10 +495,6 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
     @property
     def rollout_length_steps(self) -> int:
         return round(self.config.rollout_length_seconds / self.config.ctrl_dt)
-
-    @property
-    def eval_rollout_length_steps(self) -> int:
-        return round(self.config.eval_rollout_length_seconds / self.config.ctrl_dt)
 
     def step_engine(
         self,

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -36,7 +36,7 @@ from jaxtyping import Array, PRNGKeyArray, PyTree
 from kmv.viewer import launch_passive
 from kscale.web.gen.api import JointMetadataOutput
 from mujoco import mjx
-from omegaconf import II, MISSING
+from omegaconf import MISSING
 from PIL import Image, ImageDraw
 
 from ksim.actuators import Actuators
@@ -1260,7 +1260,6 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                     self.log_train_metrics(metrics)
                     self.log_state_timers(state)
                     self.write_logs(state)
-
 
                     if self.should_checkpoint(state):
                         model = eqx.combine(model_arr, model_static)


### PR DESCRIPTION
Removed validation stage - simply taking the most recent trajectory during rollouts to plot.
- During the scan of rollout + update epochs, save the last environment for visualization purposes.
- When visualizing, take the last epoch of such environments.

I don't love the idea of only saving the last environment for visualization purposes in the rl step function (feels a little random), but it's probably the cleanest way of doing this without recomputing.

On A100, speed goes from ~60 seconds per validation step w/ rollout to ~35 seconds per train step w/ rollout. Also, I noticed that the train step immediately following validation steps tended to be ~1.5x slower in the previous version (potentially due to some graph restructuring due to calling an extra unroll?) - right now all train steps are equivalent in speed.