### PR TITLE
Adding Minibatched RL Task Abstraction

### DIFF
--- a/examples/walking.py
+++ b/examples/walking.py
@@ -226,18 +226,6 @@ Config = TypeVar("Config", bound=HumanoidWalkingTaskConfig)
 
 
 class HumanoidWalkingTask(ksim.PPOTask[Config], Generic[Config]):
-    def get_optimizer(self) -> optax.GradientTransformation:
-        optimizer = optax.chain(
-            optax.clip_by_global_norm(self.config.max_grad_norm),
-            (
-                optax.adam(self.config.learning_rate)
-                if self.config.adam_weight_decay == 0.0
-                else optax.adamw(self.config.learning_rate, weight_decay=self.config.adam_weight_decay)
-            ),
-        )
-
-        return optimizer
-
     def get_mujoco_model(self) -> mujoco.MjModel:
         mjcf_path = (Path(__file__).parent / "data" / "scene.mjcf").resolve().as_posix()
         return mujoco.MjModel.from_xml_path(mjcf_path)
@@ -396,6 +384,18 @@ class HumanoidWalkingTask(ksim.PPOTask[Config], Generic[Config]):
             dt=self.config.ctrl_dt,
         )
 
+    def get_optimizer(self) -> optax.GradientTransformation:
+        optimizer = optax.chain(
+            optax.clip_by_global_norm(self.config.max_grad_norm),
+            (
+                optax.adam(self.config.learning_rate)
+                if self.config.adam_weight_decay == 0.0
+                else optax.adamw(self.config.learning_rate, weight_decay=self.config.adam_weight_decay)
+            ),
+        )
+
+        return optimizer
+
     def get_model(self, key: PRNGKeyArray) -> DefaultHumanoidModel:
         return DefaultHumanoidModel(
             key,
@@ -418,8 +418,8 @@ class HumanoidWalkingTask(ksim.PPOTask[Config], Generic[Config]):
         dh_joint_vel_j = observations["joint_velocity_observation"]
         com_inertia_n = observations["center_of_mass_inertia_observation"]
         com_vel_n = observations["center_of_mass_velocity_observation"]
-        # imu_acc_3 = observations["sensor_observation_imu_acc"]
-        # imu_gyro_3 = observations["sensor_observation_imu_gyro"]
+        imu_acc_3 = observations["sensor_observation_imu_acc"]
+        imu_gyro_3 = observations["sensor_observation_imu_gyro"]
         proj_grav_3 = observations["projected_gravity_observation"]
         act_frc_obs_n = observations["actuator_force_observation"]
         base_pos_3 = observations["base_position_observation"]
@@ -461,8 +461,8 @@ class HumanoidWalkingTask(ksim.PPOTask[Config], Generic[Config]):
         dh_joint_vel_j = observations["joint_velocity_observation"]
         com_inertia_n = observations["center_of_mass_inertia_observation"]
         com_vel_n = observations["center_of_mass_velocity_observation"]
-        # imu_acc_3 = observations["sensor_observation_imu_acc"]
-        # imu_gyro_3 = observations["sensor_observation_imu_gyro"]
+        imu_acc_3 = observations["sensor_observation_imu_acc"]
+        imu_gyro_3 = observations["sensor_observation_imu_gyro"]
         proj_grav_3 = observations["projected_gravity_observation"]
         act_frc_obs_n = observations["actuator_force_observation"]
         base_pos_3 = observations["base_position_observation"]

--- a/ksim/task/amp.py
+++ b/ksim/task/amp.py
@@ -368,7 +368,7 @@ class AMPTask(PPOTask[Config], Generic[Config], ABC):
         return metrics, grads
 
     @xax.jit(static_argnames=["self", "constants"], jit_level=4)
-    def _single_step(
+    def single_train_step(
         self,
         trajectories: Trajectory,
         rewards: RewardState,
@@ -377,7 +377,7 @@ class AMPTask(PPOTask[Config], Generic[Config], ABC):
         on_policy_variables: PPOVariables,
         rng: PRNGKeyArray,
     ) -> tuple[RLLoopCarry, xax.FrozenDict[str, Array], LoggedTrajectory]:
-        carry, metrics, logged_traj = super()._single_step(
+        carry, metrics, logged_traj = super().single_train_step(
             trajectories=trajectories,
             rewards=rewards,
             constants=constants,

--- a/ksim/task/amp.py
+++ b/ksim/task/amp.py
@@ -368,7 +368,7 @@ class AMPTask(PPOTask[Config], Generic[Config], ABC):
         return metrics, grads
 
     @xax.jit(static_argnames=["self", "constants"], jit_level=4)
-    def single_train_step(
+    def _single_step(
         self,
         trajectories: Trajectory,
         rewards: RewardState,
@@ -377,7 +377,7 @@ class AMPTask(PPOTask[Config], Generic[Config], ABC):
         on_policy_variables: PPOVariables,
         rng: PRNGKeyArray,
     ) -> tuple[RLLoopCarry, xax.FrozenDict[str, Array], LoggedTrajectory]:
-        carry, metrics, logged_traj = super().single_train_step(
+        carry, metrics, logged_traj = super()._single_step(
             trajectories=trajectories,
             rewards=rewards,
             constants=constants,

--- a/ksim/task/amp.py
+++ b/ksim/task/amp.py
@@ -11,7 +11,8 @@ import itertools
 import logging
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, replace as dataclass_replace
+from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 from typing import Generic, Iterable, TypeVar
 
 import attrs
@@ -367,7 +368,7 @@ class AMPTask(PPOTask[Config], Generic[Config], ABC):
         return metrics, grads
 
     @xax.jit(static_argnames=["self", "constants"], jit_level=4)
-    def _single_step(
+    def single_train_step(
         self,
         trajectories: Trajectory,
         rewards: RewardState,
@@ -376,7 +377,7 @@ class AMPTask(PPOTask[Config], Generic[Config], ABC):
         on_policy_variables: PPOVariables,
         rng: PRNGKeyArray,
     ) -> tuple[RLLoopCarry, xax.FrozenDict[str, Array], LoggedTrajectory]:
-        carry, metrics, logged_traj = super()._single_step(
+        carry, metrics, logged_traj = super().single_train_step(
             trajectories=trajectories,
             rewards=rewards,
             constants=constants,

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -22,7 +22,8 @@ import time
 import traceback
 from abc import ABC, abstractmethod
 from collections import Counter
-from dataclasses import dataclass, replace as dataclass_replace
+from dataclasses import dataclass
+from dataclasses import replace as dataclass_replace
 from pathlib import Path
 from threading import Thread
 from typing import Any, Callable, Collection, Generic, TypeVar
@@ -2103,3 +2104,160 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
 
             finally:
                 state = self.on_training_end(state)
+
+
+class MinibatchedRLTask(RLTask[Config], Generic[Config], ABC):
+    """Many RL algorithms utilize off-policy minibatch updates to train the
+    model post-rollout. This class provides a base class for these algorithms.
+    """
+
+    @abstractmethod
+    def single_train_step(
+        self,
+        trajectories: Trajectory,
+        rewards: RewardState,
+        constants: RLLoopConstants,
+        carry: RLLoopCarry,
+        on_policy_variables: PyTree,
+        rng: PRNGKeyArray,
+    ) -> tuple[RLLoopCarry, xax.FrozenDict[str, Array], LoggedTrajectory]:
+        """Perform a single training step on a minibatch of trajectories.
+
+        Args:
+            trajectories: The trajectories to train on.
+            rewards: The rewards for the trajectories.
+            constants: The constants for the training loop.
+            carry: The carry for the training loop.
+            on_policy_variables: The on-policy variables for the training loop.
+            rng: The random number generator.
+
+        Returns:
+            A tuple containing the new carry, the metrics, and the logged trajectory.
+        """
+
+    @abstractmethod
+    def get_training_variables(
+        self,
+        model: PyTree,
+        trajectory: Trajectory,
+        model_carry: PyTree,
+        rng: PRNGKeyArray,
+    ) -> tuple[PyTree, PyTree]:
+        """Gets the variables required for computing the training loss.
+
+        Args:
+            model: The user-provided model.
+            trajectory: The trajectory to get training variables for.
+            model_carry: The model carry from the previous rollout.
+            rng: A random seed.
+
+        Returns:
+            The training variables and the next carry for the model.
+        """
+
+    def update_model(
+        self,
+        *,
+        constants: RLLoopConstants,
+        carry: RLLoopCarry,
+        trajectories: Trajectory,
+        rewards: RewardState,
+        rng: PRNGKeyArray,
+    ) -> tuple[
+        RLLoopCarry,
+        xax.FrozenDict[str, Array],
+        LoggedTrajectory,
+    ]:
+        # We preserve rollout ordering and split batches by envs.
+        indices = jnp.arange(trajectories.done.shape[0])  # (num_envs)
+        indices_by_batch = indices.reshape(self.num_batches, self.batch_size)  # (num_batches, rollouts per batch)
+
+        # Gets the policy model.
+        policy_model_arr = carry.shared_state.model_arrs[0]
+        policy_model_static = constants.constants.model_statics[0]
+        policy_model = eqx.combine(policy_model_arr, policy_model_static)
+
+        # Runs the policy model on the trajectory to get the PPO variables.
+        on_policy_rngs = jax.random.split(rng, self.config.num_envs)
+        on_policy_variables, _ = jax.vmap(self.get_training_variables, in_axes=(None, 0, 0, 0))(
+            policy_model, trajectories, carry.env_states.model_carry, on_policy_rngs
+        )  # (num_envs, num_steps, training_vars)
+
+        # Loops over the trajectory batches and applies gradient updates.
+        def update_model_in_batch(
+            carry: RLLoopCarry,
+            xs: tuple[Array, PRNGKeyArray],
+        ) -> tuple[RLLoopCarry, tuple[xax.FrozenDict[str, Array], LoggedTrajectory]]:
+            batch_indices, rng = xs
+            rng, batch_rng = jax.random.split(rng)
+
+            # Gets the current batch of trajectories and rewards.
+            trajectory_batch = jax.tree.map(lambda x: x[batch_indices], trajectories)
+            reward_batch = jax.tree.map(lambda x: x[batch_indices], rewards)
+            env_states_batch = jax.tree.map(lambda x: x[batch_indices], carry.env_states)
+            on_policy_variables_batch = jax.tree.map(lambda x: x[batch_indices], on_policy_variables)
+
+            next_carry, metrics, logged_traj = self.single_train_step(
+                trajectories=trajectory_batch,
+                rewards=reward_batch,
+                constants=constants,
+                carry=dataclass_replace(carry, env_states=env_states_batch),
+                on_policy_variables=on_policy_variables_batch,
+                rng=batch_rng,
+            )
+
+            # Update the carry's shared states.
+            carry = dataclass_replace(
+                carry,
+                opt_state=next_carry.opt_state,
+                shared_state=next_carry.shared_state,
+            )
+
+            return carry, (metrics, logged_traj)
+
+        # Applies N steps of gradient updates.
+        def update_model_across_batches(
+            carry: RLLoopCarry,
+            _: None,
+        ) -> tuple[RLLoopCarry, tuple[xax.FrozenDict[str, Array], LoggedTrajectory]]:
+            carry, (metrics, trajs_for_logging) = jax.lax.scan(
+                update_model_in_batch,
+                carry,
+                (indices_by_batch, jax.random.split(rng, self.num_batches)),
+            )
+
+            # Each batch saves one trajectory for logging, get the last.
+            traj_for_logging = jax.tree.map(lambda x: x[-1], trajs_for_logging)
+
+            return carry, (metrics, traj_for_logging)
+
+        # Applies gradient update across all batches num_passes times.
+        carry, (metrics, trajs_for_logging) = jax.lax.scan(
+            update_model_across_batches,
+            carry,
+            length=self.config.num_passes,
+        )
+
+        # Get the last logged trajectory accross all full dataset passes.
+        logged_traj = jax.tree.map(lambda x: x[-1], trajs_for_logging)
+
+        # For the next rollout, we use the model carry from the output of the
+        # model update instead of the output of the rollout. This was shown to
+        # work slightly better in practice - for an  RNN model, for example,
+        # after updating the model, the model carry will be new and the
+        # previous rollout's model carry will be incorrect. This does perform
+        # some additional computation, but the impact is small.
+        off_policy_rngs = jax.random.split(rng, self.config.num_envs)
+        _, next_model_carrys = jax.vmap(self.get_training_variables, in_axes=(None, 0, 0, 0))(
+            policy_model, trajectories, carry.env_states.model_carry, off_policy_rngs
+        )
+
+        carry = dataclass_replace(
+            carry,
+            env_states=dataclass_replace(
+                carry.env_states,
+                model_carry=next_model_carrys,
+            ),
+        )
+
+        return carry, metrics, logged_traj

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -2106,10 +2106,20 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                 state = self.on_training_end(state)
 
 
-class MinibatchedRLTask(RLTask[Config], Generic[Config], ABC):
-    """Many RL algorithms utilize off-policy minibatch updates to train the
-    model post-rollout. This class provides a base class for these algorithms.
-    """
+class MinibatchedRLConfig(RLConfig):
+    """Configuration for minibatched RL tasks."""
+
+    num_passes: int = xax.field(
+        value=1,
+        help="The number of off-policy udpates over the set of trajectories",
+    )
+
+
+MinibatchedConfig = TypeVar("MinibatchedConfig", bound=MinibatchedRLConfig)
+
+
+class MinibatchedRLTask(RLTask[MinibatchedConfig], Generic[MinibatchedConfig], ABC):
+    """Base class for algorithms which perform off-policy minibatch updates."""
 
     @abstractmethod
     def single_train_step(


### PR DESCRIPTION
It generally felt like the PPO minibatching logic should be reusable in case we implement other algorithm classes. Added as separate class instead of porting over to RL because not all RL algorithms will perform offline updates in minibatches.

Also, I wanted to make AMP not directly depend on PPO, such that we could define it like:

```
class HumanoidAMPTask(AMPTask[Config], PPOTask[Config]):
```

It's possible to do this right now by having `AMPTask` inherit from `MinibatchedRLTask`, but it feels super precarious because it relies on the user specifying the multiple inheritance in the right order.

Overall, I like the idea of being able to implement `single_train_step` (or to that end, maybe just `get_loss_and_metrics`) atomically such that the end-user can easily mix and match objectives. Will help with the co-training ideas I had. I haven't thought of a good way to do this yet, but will update when I do.