### PR TITLE
Simplifying AMP Reward

### DIFF
--- a/ksim/task/amp.py
+++ b/ksim/task/amp.py
@@ -78,7 +78,7 @@ class AMPReward(Reward):
             )
 
         discriminator_logits = trajectory.aux_outputs[DISCRIMINATOR_OUTPUT_KEY]
-        reward = jnp.maximum(0.0, 1.0 - 0.25 * (1 - discriminator_logits) ** 2)
+        reward = discriminator_logits + 1.0
         return reward
 
 


### PR DESCRIPTION
The original AMP reward never really made sense to me 1) because the max term reduces expressiveness of the term and 2) I don't understand why you'd want to add a quadratic transformation on discriminator logits when they're trained to linearly interpolate between -1 and 1.