### PR TITLE
add min level field to curricula

### DIFF
--- a/ksim/__init__.py
+++ b/ksim/__init__.py
@@ -1,6 +1,6 @@
 """Defines the main ksim API."""
 
-__version__ = "0.0.42"
+__version__ = "0.0.43"
 
 from .actuators import *
 from .commands import *


### PR DESCRIPTION
See title. We sometimes want to leverage a progressive curriculum that starts with some initial value. E.g., having some push force often helps the policy learn to walk