### PR TITLE
Pass full metadata (not just jointmetadata) to actuator creation, and better metadata handling

### DIFF
--- a/examples/pseudo_ik.py
+++ b/examples/pseudo_ik.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import mujoco
 import xax
 from jaxtyping import Array, PRNGKeyArray
-from kscale.web.gen.api import JointMetadataOutput
+from kscale.web.gen.api import RobotURDFMetadataOutput
 
 import ksim
 from ksim.utils.mujoco import remove_mujoco_joints_except
@@ -117,12 +117,12 @@ class HumanoidPseudoIKTask(HumanoidWalkingRNNTask[Config], Generic[Config]):
     def get_actuators(
         self,
         physics_model: ksim.PhysicsModel,
-        metadata: dict[str, JointMetadataOutput] | None = None,
+        metadata: RobotURDFMetadataOutput | None = None,
     ) -> ksim.Actuators:
         assert metadata is not None, "Metadata is required"
         return ksim.MITPositionActuators(
             physics_model=physics_model,
-            joint_name_to_metadata=metadata,
+            metadata=metadata,
             freejoint_first=False,
         )
 

--- a/examples/walking.py
+++ b/examples/walking.py
@@ -1,11 +1,9 @@
 """Defines simple task for training a walking policy for the default humanoid."""
 
-import asyncio
-import logging
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Generic, Self, TypeVar
+from typing import Generic, TypeVar
 
 import distrax
 import equinox as eqx
@@ -15,10 +13,10 @@ import mujoco
 import optax
 import xax
 from jaxtyping import Array, PRNGKeyArray
-from kscale.web.gen.api import JointMetadataOutput, RobotURDFMetadataOutput
-from ksim.utils.mujoco import get_actuator_metadata
+from kscale.web.gen.api import RobotURDFMetadataOutput
 
 import ksim
+from ksim.utils.mujoco import get_actuator_metadata
 
 NUM_JOINTS = 21
 
@@ -253,9 +251,7 @@ class HumanoidWalkingTask(ksim.PPOTask[Config], Generic[Config]):
 
     def get_mujoco_model_metadata(self, mj_model: mujoco.MjModel) -> RobotURDFMetadataOutput:
         return RobotURDFMetadataOutput(
-            joint_name_to_metadata=ksim.get_joint_metadata(
-                mj_model, kp=100.0, kd=5.0, armature=1e-4, friction=1e-6
-            ),
+            joint_name_to_metadata=ksim.get_joint_metadata(mj_model, kp=100.0, kd=5.0, armature=1e-4, friction=1e-6),
             actuator_type_to_metadata=get_actuator_metadata(mj_model),
             control_frequency=None,
         )

--- a/examples/walking.py
+++ b/examples/walking.py
@@ -263,12 +263,12 @@ class HumanoidWalkingTask(ksim.PPOTask[Config], Generic[Config]):
     def get_actuators(
         self,
         physics_model: ksim.PhysicsModel,
-        metadata: dict[str, JointMetadataOutput] | None = None,
+        metadata: RobotURDFMetadataOutput | None = None,
     ) -> ksim.Actuators:
         assert metadata is not None, "Metadata is required"
         return ksim.MITPositionActuators(
             physics_model=physics_model,
-            joint_name_to_metadata=metadata,
+            joint_name_to_metadata=metadata.joint_name_to_metadata,
         )
 
     def get_physics_randomizers(self, physics_model: ksim.PhysicsModel) -> list[ksim.PhysicsRandomizer]:

--- a/examples/walking.py
+++ b/examples/walking.py
@@ -268,7 +268,7 @@ class HumanoidWalkingTask(ksim.PPOTask[Config], Generic[Config]):
         assert metadata is not None, "Metadata is required"
         return ksim.MITPositionActuators(
             physics_model=physics_model,
-            joint_name_to_metadata=metadata.joint_name_to_metadata,
+            metadata=metadata,
         )
 
     def get_physics_randomizers(self, physics_model: ksim.PhysicsModel) -> list[ksim.PhysicsRandomizer]:

--- a/examples/walking_amp.py
+++ b/examples/walking_amp.py
@@ -417,12 +417,12 @@ class HumanoidWalkingAMPTask(ksim.AMPTask[Config], Generic[Config]):
     def get_actuators(
         self,
         physics_model: ksim.PhysicsModel,
-        metadata: dict[str, ksim.JointMetadataOutput] | None = None,
+        metadata: RobotURDFMetadataOutput | None = None,
     ) -> ksim.Actuators:
         assert metadata is not None, "Metadata is required"
         return ksim.MITPositionActuators(
             physics_model=physics_model,
-            joint_name_to_metadata=metadata,
+            metadata=metadata,
         )
 
     def get_physics_randomizers(self, physics_model: ksim.PhysicsModel) -> list[ksim.PhysicsRandomizer]:

--- a/examples/walking_amp.py
+++ b/examples/walking_amp.py
@@ -1,12 +1,10 @@
 # mypy: disable-error-code="override"
 """Example walking task using Adversarial Motion Priors."""
 
-import asyncio
-import logging
 import math
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Generic, Self, TypeVar
+from typing import Callable, Generic, TypeVar
 
 import distrax
 import equinox as eqx
@@ -17,11 +15,10 @@ import numpy as np
 import optax
 import xax
 from jaxtyping import Array, PRNGKeyArray
-
-from kscale.web.gen.api import JointMetadataOutput, RobotURDFMetadataOutput
-from ksim.utils.mujoco import get_actuator_metadata
+from kscale.web.gen.api import RobotURDFMetadataOutput
 
 import ksim
+from ksim.utils.mujoco import get_actuator_metadata
 
 NUM_JOINTS = 21
 
@@ -407,9 +404,7 @@ class HumanoidWalkingAMPTask(ksim.AMPTask[Config], Generic[Config]):
 
     def get_mujoco_model_metadata(self, mj_model: mujoco.MjModel) -> RobotURDFMetadataOutput:
         return RobotURDFMetadataOutput(
-            joint_name_to_metadata=ksim.get_joint_metadata(
-                mj_model, kp=1.0, kd=0.1, armature=1e-2, friction=1e-6
-            ),
+            joint_name_to_metadata=ksim.get_joint_metadata(mj_model, kp=1.0, kd=0.1, armature=1e-2, friction=1e-6),
             actuator_type_to_metadata=get_actuator_metadata(mj_model),
             control_frequency=None,
         )

--- a/ksim/actuators.py
+++ b/ksim/actuators.py
@@ -103,6 +103,8 @@ class MITPositionActuators(Actuators):
         ctrl_clip_list = [jnp.inf] * len(ctrl_name_to_idx)
 
         self.freejoint_first = freejoint_first
+        if metadata.joint_name_to_metadata is None:
+            raise ValueError("Joint metadata is required for MITPositionActuators")
         joint_name_to_metadata = metadata.joint_name_to_metadata
 
         for joint_name, params in joint_name_to_metadata.items():

--- a/ksim/actuators.py
+++ b/ksim/actuators.py
@@ -16,7 +16,7 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PRNGKeyArray, PyTree
-from kscale.web.gen.api import JointMetadataOutput
+from kscale.web.gen.api import JointMetadataOutput, RobotURDFMetadataOutput
 
 from ksim.types import PhysicsData, PhysicsModel
 from ksim.utils.mujoco import get_ctrl_data_idx_by_name
@@ -89,7 +89,7 @@ class MITPositionActuators(Actuators):
     def __init__(
         self,
         physics_model: PhysicsModel,
-        joint_name_to_metadata: dict[str, JointMetadataOutput],
+        metadata: RobotURDFMetadataOutput,
         action_noise: float = 0.0,
         action_noise_type: NoiseType = "none",
         torque_noise: float = 0.0,
@@ -103,6 +103,7 @@ class MITPositionActuators(Actuators):
         ctrl_clip_list = [jnp.inf] * len(ctrl_name_to_idx)
 
         self.freejoint_first = freejoint_first
+        joint_name_to_metadata = metadata.joint_name_to_metadata
 
         for joint_name, params in joint_name_to_metadata.items():
             actuator_name = self.get_actuator_name(joint_name)
@@ -173,7 +174,7 @@ class MITPositionVelocityActuators(MITPositionActuators):
     def __init__(
         self,
         physics_model: PhysicsModel,
-        joint_name_to_metadata: dict[str, JointMetadataOutput],
+        metadata: RobotURDFMetadataOutput,
         pos_action_noise: float = 0.0,
         pos_action_noise_type: NoiseType = "none",
         vel_action_noise: float = 0.0,
@@ -184,7 +185,7 @@ class MITPositionVelocityActuators(MITPositionActuators):
     ) -> None:
         super().__init__(
             physics_model=physics_model,
-            joint_name_to_metadata=joint_name_to_metadata,
+            metadata=metadata,
             action_noise=pos_action_noise,
             action_noise_type=pos_action_noise_type,
             torque_noise=torque_noise,

--- a/ksim/actuators.py
+++ b/ksim/actuators.py
@@ -16,7 +16,7 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PRNGKeyArray, PyTree
-from kscale.web.gen.api import JointMetadataOutput, RobotURDFMetadataOutput
+from kscale.web.gen.api import RobotURDFMetadataOutput
 
 from ksim.types import PhysicsData, PhysicsModel
 from ksim.utils.mujoco import get_ctrl_data_idx_by_name

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -670,8 +670,6 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         return mj_model
 
     def get_mujoco_model_metadata(self, mj_model: mujoco.MjModel) -> RobotURDFMetadataOutput:
-        # Fallback to automatically generated, minimal metadata when no
-        # handcrafted metadata.json is available.
         return get_metadata(mj_model)
 
     def get_mjx_model(self, mj_model: mujoco.MjModel) -> mjx.Model:
@@ -1537,7 +1535,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             mj_model = self.get_mujoco_model()
             mj_model = self.set_mujoco_model_opts(mj_model)
             metadata = self.get_mujoco_model_metadata(mj_model)
-            log_joint_config_table(mj_model, metadata.joint_name_to_metadata, self.logger)
+            log_joint_config_table(mj_model, metadata, self.logger)
 
             randomizers = self.get_physics_randomizers(mj_model)
 
@@ -1711,7 +1709,6 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             raise ValueError("No models found")
 
         metadata = self.get_mujoco_model_metadata(mj_model)
-        # Serialize metadata for logging
         metadata_str = json.dumps(metadata.model_dump(), indent=2, sort_keys=True)
         self.logger.log_file("mujoco_metadata.json", metadata_str)
         engine = self.get_engine(physics_model, metadata)
@@ -2004,7 +2001,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             mj_model: PhysicsModel = self.get_mujoco_model()
             mj_model = self.set_mujoco_model_opts(mj_model)
             metadata = self.get_mujoco_model_metadata(mj_model)
-            log_joint_config_table(mj_model, metadata.joint_name_to_metadata, self.logger)
+            log_joint_config_table(mj_model, metadata, self.logger)
 
             constants, carry, state = self.initialize_rl_training(mj_model, rng)
 

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -732,7 +732,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
     def get_actuators(
         self,
         physics_model: PhysicsModel,
-        metadata: dict[str, JointMetadataOutput] | None = None,
+        metadata: RobotURDFMetadataOutput | None = None,
     ) -> Actuators: ...
 
     @abstractmethod

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -695,7 +695,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             engine_type=engine_type_from_physics_model(physics_model),
             resets=self.get_resets(physics_model),
             events=self.get_events(physics_model),
-            actuators=self.get_actuators(physics_model, metadata.joint_name_to_metadata if metadata else None),
+            actuators=self.get_actuators(physics_model, metadata),
             dt=float(physics_model.opt.timestep),
             ctrl_dt=self.config.ctrl_dt,
             max_action_latency=self.config.max_action_latency,

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -41,7 +41,7 @@ import tqdm
 import xax
 from dpshdl.dataset import Dataset
 from jaxtyping import Array, PRNGKeyArray, PyTree
-from kscale.web.gen.api import RobotURDFMetadataOutput, JointMetadataOutput, ActuatorMetadataOutput
+from kscale.web.gen.api import JointMetadataOutput, RobotURDFMetadataOutput
 from mujoco import mjx
 from omegaconf import MISSING
 from PIL import Image, ImageDraw
@@ -73,13 +73,12 @@ from ksim.types import (
     Trajectory,
 )
 from ksim.utils.mujoco import (
-    get_joint_metadata,
     get_joint_names_in_order,
+    get_metadata,
     get_position_limits,
     get_torque_limits,
     load_model,
     log_joint_config_table,
-    get_metadata,
 )
 from ksim.viewer import DefaultMujocoViewer, GlfwMujocoViewer, RenderMode
 from ksim.vis import Marker, configure_scene

--- a/ksim/utils/mujoco.py
+++ b/ksim/utils/mujoco.py
@@ -288,13 +288,14 @@ def get_joint_metadata(
 
 def log_joint_config_table(
     model: PhysicsModel,
-    joint_metadata: dict[str, JointMetadataOutput],
+    metadata: RobotURDFMetadataOutput,
     xax_logger: xax.Logger,
 ) -> None:
     """Log configuration of joints and actuators in a table."""
     actuator_name_to_nn_id = get_ctrl_data_idx_by_name(model)
     joint_names = get_joint_names_in_order(model)
     joint_limits = get_position_limits(model)
+    joint_metadata = metadata.joint_name_to_metadata
 
     # The \n is to make the table headers take up less horizontal space.
     headers = [

--- a/ksim/utils/mujoco.py
+++ b/ksim/utils/mujoco.py
@@ -254,7 +254,24 @@ def get_metadata(model: PhysicsModel) -> RobotURDFMetadataOutput:
 
 def get_actuator_metadata(model: PhysicsModel) -> dict[str, ActuatorMetadataOutput]:
     """Generate *default* actuator metadata for a MuJoCo model."""
-    metadata: dict[str, ActuatorMetadataOutput] = {"motor": ActuatorMetadataOutput(actuator_type="motor")}
+    metadata: dict[str, ActuatorMetadataOutput] = {
+        "motor": ActuatorMetadataOutput(
+            actuator_type="motor",
+            sysid="",
+            max_torque=None,
+            armature=None,
+            damping=None,
+            frictionloss=None,
+            vin=None,
+            kt=None,
+            R=None,
+            vmax=None,
+            amax=None,
+            max_velocity=None,
+            max_pwm=None,
+            error_gain=None,
+        )
+    }
     return metadata
 
 
@@ -295,6 +312,9 @@ def log_joint_config_table(
     actuator_name_to_nn_id = get_ctrl_data_idx_by_name(model)
     joint_names = get_joint_names_in_order(model)
     joint_limits = get_position_limits(model)
+
+    if metadata.joint_name_to_metadata is None:
+        raise ValueError("Joint metadata is required for the joint config table")
     joint_metadata = metadata.joint_name_to_metadata
 
     # The \n is to make the table headers take up less horizontal space.

--- a/ksim/utils/mujoco.py
+++ b/ksim/utils/mujoco.py
@@ -44,7 +44,7 @@ import mujoco
 import numpy as np
 import xax
 from jaxtyping import Array
-from kscale.web.gen.api import RobotURDFMetadataOutput, JointMetadataOutput, ActuatorMetadataOutput
+from kscale.web.gen.api import ActuatorMetadataOutput, JointMetadataOutput, RobotURDFMetadataOutput
 from mujoco import mjx
 from tabulate import tabulate
 
@@ -245,7 +245,6 @@ def get_torque_limits(model: PhysicsModel) -> dict[str, tuple[float, float]]:
 
 def get_metadata(model: PhysicsModel) -> RobotURDFMetadataOutput:
     """Return default metadata for a MuJoCo model."""
-
     return RobotURDFMetadataOutput(
         joint_name_to_metadata=get_joint_metadata(model),
         actuator_type_to_metadata=get_actuator_metadata(model),


### PR DESCRIPTION
Previously, we kinds just assumed all of metadata was _just_ JointMetadata. This PR corrects that problem so that now RobotURDFMetadata (which contains JointMetadata, ActuatorMetadata and control frequency) is the "metadata" variable of choice.

- now MITPositionActuators takes RobotURDFMetadata instead of just joint metadata, so if we add more detailed actuator metadata in the future, we won't have to refactor it.

Corresponding kbot PR : https://github.com/kscalelabs/kscale-humanoid-benchmark/pull/26