### PR TITLE
Add config option to exclude certain rewards from combined reward plotting

### DIFF
--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -380,7 +380,10 @@ class RLConfig(xax.Config):
         value=False,
         help="If true, profile memory usage.",
     )
-
+    exclude_combined_reward_components: list[str] = xax.field(
+        value=[],
+        help="If provided, exclude these components from the combined reward plot.",
+    )
     # Training parameters.
     num_envs: int = xax.field(
         value=MISSING,
@@ -1191,6 +1194,8 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         # Add a combined plot with all reward components for easy comparison
         def plot_combined_rewards(fig: plt.Figure, ax: plt.Axes) -> None:
             for key, value in logged_traj.rewards.components.items():
+                if key in self.config.exclude_combined_reward_components:
+                    continue
                 processed_value = value.reshape(value.shape[0], -1)
                 if processed_value.shape[1] > 1:
                     processed_value = processed_value.mean(axis=1)


### PR DESCRIPTION
E.g. if a reward like `StayAlive` is significantly larger in magnitude than other components, we might want to exclude it to better see the scale of the other components.
<img width="855" alt="image" src="https://github.com/user-attachments/assets/99713dff-cc9e-4893-a7bc-4ac2b286b00d" />
vs
<img width="1212" alt="image" src="https://github.com/user-attachments/assets/9fe86382-93d5-4a67-8d9a-5c658043d457" />
