### PR TITLE
fix indexing bug

### DIFF
--- a/ksim/__init__.py
+++ b/ksim/__init__.py
@@ -1,6 +1,6 @@
 """Defines the main ksim API."""
 
-__version__ = "0.1.93"
+__version__ = "0.1.94"
 
 from .actuators import *
 from .commands import *

--- a/ksim/rewards.py
+++ b/ksim/rewards.py
@@ -498,10 +498,9 @@ class JointDeviationPenalty(Reward):
     joint_weights: tuple[float, ...] | None = attrs.field(default=None)
 
     def get_reward(self, trajectory: Trajectory) -> Array:
-        diff = (
-            trajectory.qpos[..., jnp.array(self.joint_indices) + 7]
-            - jnp.array(self.joint_targets)[jnp.array(self.joint_indices)]
-        )
+        qpos_sel = trajectory.qpos[..., jnp.array(self.joint_indices) + 7]
+        target = jnp.asarray(self.joint_targets)
+        diff = qpos_sel - target
 
         if self.joint_weights is not None:
             diff *= jnp.array(self.joint_weights)


### PR DESCRIPTION
In joint deviation penalty, we want to find the difference from the actual joint pose to the given target.

however you can be given targets only for a subset of joints, not all of them

therefore, indexing like this 

```python
 jnp.array(self.joint_targets)[jnp.array(self.joint_indices)]
 ```
 
 is wrong because it assumes there are targets defined for every single joint, and fails silently because jax does not throw index out of bounds error, as explained here:
 
 "the index is clamped to the bounds of the array since something must be returned"
 https://www.kaggle.com/code/dschettler8845/pt-3-learning-jax-more-pitfalls-to-avoid/code?utm_source=chatgpt.com

this PR fixes that problem by not indexing into joint targets because you don't need to.