### PR TITLE
lower live buffer length (default is too slow)

### DIFF
--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -551,7 +551,7 @@ class RLConfig(xax.Config):
         help="The name or id of the camera to use in rendering.",
     )
     live_reward_buffer_size: int = xax.field(
-        value=32,
+        value=4,
         help="Size of the rolling buffer for computing live rewards",
     )
 


### PR DESCRIPTION
Myself, and other users (see issue https://github.com/kscalelabs/ksim/issues/431) have noticed that the run_mode=view can be slow. I think the loop spends most of its time building and maintaining the rewards.

For example I get 8-9 physics iterations per second with live reward buffer size = 4, and 4-7 iterations per second with the buffer size = 32

So this PR lowers the live rewards buffer size from 32 to 4. 