### PR TITLE
use correct index for sim time horizon

### DIFF
--- a/ksim/task/amp.py
+++ b/ksim/task/amp.py
@@ -477,7 +477,7 @@ class AMPTask(PPOTask[Config], Generic[Config], ABC):
 
         real_motions_full = carry.shared_state.aux_values[REAL_MOTIONS_KEY]
 
-        sim_t = trajectories.done.shape[0]  # match sim horizon
+        sim_t = trajectories.done.shape[-1]
 
         real_batch = self._make_real_batch(
             motions=real_motions_full,


### PR DESCRIPTION
Was mistakenly using the trajectory batch dimension to extend / trim the real motions to feed into discriminator