### PR TITLE
make the qt viewer timeout a config option

### DIFF
--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -554,6 +554,10 @@ class RLConfig(xax.Config):
         value=4,
         help="Size of the rolling buffer for computing live rewards",
     )
+    viewer_timeout_secs: float = xax.field(
+        value=5.0,
+        help="The timeout for the QT viewer.",
+    )
 
 
 Config = TypeVar("Config", bound=RLConfig)
@@ -582,6 +586,7 @@ def get_qt_viewer(
         camera_elevation=config.render_elevation,
         camera_lookat=config.render_lookat,
         track_body_id=config.render_track_body_id,
+        timeout_secs=config.viewer_timeout_secs,
     )
 
 

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -555,7 +555,7 @@ class RLConfig(xax.Config):
         help="Size of the rolling buffer for computing live rewards",
     )
     viewer_timeout_secs: float = xax.field(
-        value=5.0,
+        value=10.0,
         help="The timeout for the QT viewer.",
     )
 


### PR DESCRIPTION
e.g. if your mac takes longer than 5 seconds to initialize the qt viewer, you want to increase the timeout