### PR TITLE
horizon based value normalization

### DIFF
--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -58,7 +58,6 @@ def compute_ppo_inputs(
     successes_t: Array,
     decay_gamma: float,
     gae_lambda: float,
-    rollout_length_steps: int,
     normalize_advantages: bool = False,
     monte_carlo_returns: bool = False,
 ) -> PPOInputs:
@@ -87,7 +86,8 @@ def compute_ppo_inputs(
 
         # 1-step bootstrap on successful terminations.
         trunc_mask_t = jnp.where(successes_t, 1.0, 0.0)
-        bootstrapped_rewards_t = rewards_t / rollout_length_steps + decay_gamma * values_t * trunc_mask_t
+        discount_horizon = 1 / (1 - decay_gamma)
+        bootstrapped_rewards_t = rewards_t / discount_horizon + decay_gamma * values_t * trunc_mask_t
 
         mask_t = jnp.where(dones_t, 0.0, 1.0)
 
@@ -465,7 +465,6 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
                 successes_t=trajectory.success,
                 decay_gamma=self.config.gamma,
                 gae_lambda=self.config.lam,
-                rollout_length_steps=self.rollout_length_steps,
                 normalize_advantages=self.config.normalize_advantages,
                 monte_carlo_returns=self.config.monte_carlo_returns,
             )

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -45,7 +45,6 @@ class PPOVariables:
     static_argnames=[
         "decay_gamma",
         "gae_lambda",
-        "rollout_length_steps",
         "normalize_advantages",
         "monte_carlo_returns",
     ],


### PR DESCRIPTION
Value normalization is good and helps learning but it makes no sense to divide by `rollout_length_steps`. Especially now that we properly deal with values for truncated episodes https://github.com/kscalelabs/ksim/pull/410. `rollout_length_steps` is just an arbitrary number that we scale by, with the side effect that this hyperparam affects results in unintended ways.

It makes more sense to normalize by the effective discount horizon: $1 / (1 - \gamma)$

I tried this on kbot-joystick:dev-bart and it trains slightly better:


![image](https://github.com/user-attachments/assets/d338a0a1-2d2c-4421-8964-a6f6bc09e55c)
![image](https://github.com/user-attachments/assets/fb6c81b6-3bbd-425b-9f4f-77e31d343d38)


Light blue/gray is this PR, green/purple is ksim master. No other changes made.


Note that in kbot-joystick:dev-bart rewards are generally between 0 and 1. For other train setups where rewards are not close to 1, you might get different results. 

Ideally we should normalize based on std and mean of values in rollout buffer to completely mitigate this