### PR TITLE
Add functionality to render long trajectories

### DIFF
--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -669,7 +669,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         if self.config.render_length_seconds > self.config.rollout_length_seconds:
             logger.info(
                 "The render length %ss is greater than the rollout length %ss! "
-                "Real algorithm metrics will not be logged. "
+                "Algorithm metrics will not be logged because the rendered trajectory was not used for training. "
                 "To log algorithm metrics, set the render length to be equal or less than the rollout length.",
                 self.config.render_length_seconds,
                 self.config.rollout_length_seconds,

--- a/ksim/task/rl.py
+++ b/ksim/task/rl.py
@@ -465,7 +465,7 @@ class RLConfig(xax.Config):
         value=640,
         help="The height of the rendered images during the validation phase.",
     )
-    render_length_seconds: float | None = xax.field(
+    render_length_seconds: float = xax.field(
         value=5.0,
         help="The number of seconds to rollout each environment during evaluation.",
     )
@@ -664,6 +664,15 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             raise ValueError(
                 f"The number of environments ({self.config.num_envs}) must be divisible by "
                 f"the batch size ({self.config.batch_size})"
+            )
+
+        if self.config.render_length_seconds > self.config.rollout_length_seconds:
+            logger.info(
+                "The render length %ss is greater than the rollout length %ss! "
+                "Real algorithm metrics will not be logged. "
+                "To log algorithm metrics, set the render length to be equal or less than the rollout length.",
+                self.config.render_length_seconds,
+                self.config.rollout_length_seconds,
             )
 
     @functools.cached_property
@@ -874,6 +883,10 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
     @property
     def rollout_length_steps(self) -> int:
         return round(self.config.rollout_length_seconds / self.config.ctrl_dt)
+
+    @property
+    def render_length_steps(self) -> int:
+        return round(self.config.render_length_seconds / self.config.ctrl_dt)
 
     @property
     def rollout_num_samples(self) -> int:
@@ -1175,7 +1188,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             log_callback: A callable function to run to log a given image.
         """
         # Clips the trajectory to the desired length.
-        if self.config.render_length_seconds is not None:
+        if self.config.render_length_seconds < self.config.rollout_length_seconds:
             logged_traj = self._crop_to_length(logged_traj, self.config.render_length_seconds)
 
         def create_plot_image(
@@ -1265,7 +1278,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             key: The logging key to use.
         """
         # Clips the trajectory to the desired length.
-        if self.config.render_length_seconds is not None:
+        if self.config.render_length_seconds < self.config.rollout_length_seconds:
             logged_traj = self._crop_to_length(logged_traj, self.config.render_length_seconds)
 
         # Logs the video of the trajectory.
@@ -1394,12 +1407,13 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
     ) -> Trajectory:
         return trajectory
 
-    @xax.jit(static_argnames=["self", "constants"], jit_level=JitLevel.UNROLL)
+    @xax.jit(static_argnames=["self", "constants", "num_steps"], jit_level=JitLevel.UNROLL)
     def _single_unroll(
         self,
         constants: RolloutConstants,
         env_state: RolloutEnvState,
         shared_state: RolloutSharedState,
+        num_steps: int,
     ) -> tuple[Trajectory, RewardState, RolloutEnvState]:
         # Applies randomizations to the model.
         shared_state = replace(
@@ -1419,7 +1433,7 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
         env_state, trajectory = xax.scan(
             scan_fn,
             env_state,
-            length=self.rollout_length_steps,
+            length=num_steps,
             jit_level=JitLevel.UNROLL,
         )
 
@@ -1471,13 +1485,14 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             # Rolls out a new trajectory.
             vmapped_unroll = xax.vmap(
                 self._single_unroll,
-                in_axes=(None, 0, None),
+                in_axes=(None, 0, None, None),
                 jit_level=JitLevel.UNROLL,
             )
             trajectories, rewards, env_state = vmapped_unroll(
                 constants.constants,
                 carry_i.env_states,
                 carry_i.shared_state,
+                self.rollout_length_steps,
             )
 
             # Runs update on the previous trajectory.
@@ -2074,10 +2089,12 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
             ) -> tuple[Trajectory, RewardState, RolloutEnvState]:
                 vmapped_unroll = xax.vmap(
                     self._single_unroll,
-                    in_axes=(None, 0, None),
+                    in_axes=(None, 0, None, None),
                     jit_level=JitLevel.UNROLL,
                 )
-                return vmapped_unroll(rollout_constants, rollout_env_state, rollout_shared_state)
+                return vmapped_unroll(
+                    rollout_constants, rollout_env_state, rollout_shared_state, self.rollout_length_steps
+                )
 
             with TrajectoryDataset.writer(save_path, num_batches * self.batch_size) as writer:
                 for _ in tqdm.trange(num_batches):
@@ -2249,13 +2266,19 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                         if valid_step:
                             cur_time = time.monotonic()
                             full_render = cur_time - last_full_render_time > self.config.render_full_every_n_seconds
-                            self._log_logged_trajectory_video(
-                                logged_traj=logged_traj,
-                                markers=markers,
-                                viewer=viewer,
-                                key="full trajectory" if full_render else "trajectory",
-                            )
+
                             if full_render:
+                                if self.config.render_length_seconds > self.config.rollout_length_seconds:
+                                    long_traj, rewards, _ = self._single_unroll(
+                                        constants=constants.constants,
+                                        env_state=jax.tree.map(lambda arr: arr[-1], carry.env_states),
+                                        shared_state=carry.shared_state,
+                                        num_steps=self.render_length_steps,
+                                    )
+                                    logged_traj = LoggedTrajectory(
+                                        trajectory=long_traj, rewards=rewards, metrics=xax.FrozenDict()
+                                    )
+
                                 self._log_logged_trajectory_graphs(
                                     logged_traj=logged_traj,
                                     log_callback=lambda key, value, namespace: self.logger.log_image(
@@ -2264,7 +2287,15 @@ class RLTask(xax.Task[Config], Generic[Config], ABC):
                                         namespace=namespace,
                                     ),
                                 )
+
                                 last_full_render_time = cur_time
+
+                            self._log_logged_trajectory_video(
+                                logged_traj=logged_traj,
+                                markers=markers,
+                                viewer=viewer,
+                                key="trajectory",
+                            )
 
                         # Updates the step and sample counts.
                         num_steps = self.config.epochs_per_log_step


### PR DESCRIPTION
Previously, we could only render trajectories up the length of collected data during training.
This PR will unroll a new trajectory to specified length for a single environment if `render_length_seconds` > `rollout_length_seconds`