### PR TITLE
Fixed examples/walking.py and updated README run_mode command

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,5 +47,5 @@ ksim-visualize-reference examples/data/humanoid_amp_walk_ref.npz --model example
 ## To visualize the reference motion in your AMP task, run with the following config:
 
 ```
-python -m examples.walking_amp run_mode=view_motion
+python -m examples.walking_amp run_mode=view
 ```

--- a/ksim/task/ppo.py
+++ b/ksim/task/ppo.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, replace
 from typing import Generic, Mapping, TypeVar
 
 import chex
+import optax
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -544,6 +545,21 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
             rng,
         )
         return metrics, logged_trajectory, grads
+    
+    def _apply_gradients(
+        self,
+        model_arr: PyTree,
+        grads: PyTree,
+        optimizer: optax.GradientTransformation,
+        opt_state: PyTree,
+    ) -> tuple[PyTree, PyTree, xax.FrozenDict[str, Array]]:        
+        # Update optim and parameters
+        updates, new_opt_state = optimizer.update(grads, opt_state, params=model_arr)
+        new_model_arr = eqx.apply_updates(model_arr, updates)
+
+        grad_metrics = xax.FrozenDict({}) # left metrics empty for now
+
+        return new_model_arr, new_opt_state, grad_metrics
 
     @xax.jit(static_argnames=["self", "constants"], jit_level=JitLevel.RL_CORE)
     def _single_step(
@@ -572,8 +588,8 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
             rng=rng,
         )
 
-        # Applies the gradients with clipping.
-        new_model_arr, new_opt_state, grad_metrics = self.apply_gradients_with_clipping(
+        # Applies the gradients.
+        new_model_arr, new_opt_state, grad_metrics = self._apply_gradients(
             model_arr=model_arr,
             grads=grads,
             optimizer=optimizer,
@@ -591,7 +607,7 @@ class PPOTask(RLTask[Config], Generic[Config], ABC):
         )
 
         # Gets the metrics dictionary.
-        metrics: xax.FrozenDict[str, Array] = xax.FrozenDict(ppo_metrics.unfreeze() | grad_metrics)
+        metrics: xax.FrozenDict[str, Array] = xax.FrozenDict({**ppo_metrics.unfreeze(), **grad_metrics.unfreeze()})
 
         return carry, metrics, logged_trajectory
 


### PR DESCRIPTION
fixed walking.py example and README run_mode command. 
1. Updated PPOTask _apply_gradients_with_clipping function to _apply_gradients only, 
2. clipping added to walking.py optax.chain() with clip_by_global_norm, 
3. added global_grad_clip field to HumanoidWAlkingTaskConfig
4. Update README command to run_mode=view

*** Left grad_metrics as an empty xax.FrozenDict in the _apply_gradients function  

