### PR TITLE
Remove unused attribute from LinearPushEvent

### DIFF
--- a/examples/walking.py
+++ b/examples/walking.py
@@ -386,7 +386,6 @@ class WalkingTask(ksim.PPOTask[Config], Generic[Config]):
     def get_events(self, physics_model: ksim.PhysicsModel) -> list[ksim.Event]:
         return [
             ksim.LinearPushEvent(
-                linvel=1.0,
                 interval_range=(2.0, 5.0),
             ),
             ksim.JumpEvent(

--- a/ksim/events.py
+++ b/ksim/events.py
@@ -64,7 +64,6 @@ class Event(ABC):
 class LinearPushEvent(Event):
     """Randomly push the robot in a linear direction."""
 
-    linvel: float = attrs.field()
     vel_range: tuple[float, float] = attrs.field(default=(0.0, 1.0))
     interval_range: tuple[float, float] = attrs.field()
     curriculum_range: tuple[float, float] = attrs.field(default=(0.0, 1.0))


### PR DESCRIPTION
`LinearPushEvent` doesn't actually use `linvel` (the examples I've seen for k-bot all seem to assume it does fwiw!), it just uses `vel_range`