### PR TITLE
implement zero offset

### DIFF
--- a/examples/kbot/train.py
+++ b/examples/kbot/train.py
@@ -452,11 +452,9 @@ class HumanoidWalkingTask(ksim.PPOTask[HumanoidWalkingTaskConfig]):
         metadata: ksim.Metadata | None = None,
     ) -> ksim.Actuators:
         assert metadata is not None, "Metadata is required"
-        return ksim.BiasedPositionActuators(
+        return ksim.PositionActuators(
             physics_model=physics_model,
             metadata=metadata,
-            action_bias=ksim.UniformRandomVariable(mean=0.0, mag=math.radians(3.0)),
-            torque_bias=ksim.UniformRandomVariable(mean=0.0, mag=3.0),
             action_noise=ksim.AdditiveGaussianNoise(std=0.01),
             torque_noise=ksim.AdditiveGaussianNoise(std=0.01),
         )

--- a/examples/kbot/train.py
+++ b/examples/kbot/train.py
@@ -889,6 +889,8 @@ if __name__ == "__main__":
             ctrl_dt=0.02,
             action_latency_range=(0.001, 0.01),  # Simulate 1-10ms of latency.
             drop_action_prob=0.05,  # Drop 5% of commands.
+            zero_offset_std=math.radians(3.0),
+            zero_offset_mag=math.radians(3.0),
             # Visualization parameters.
             # If running this on Mac and you are getting segfaults,
             # you might need to disable `render_markers`

--- a/examples/walking.py
+++ b/examples/walking.py
@@ -779,7 +779,8 @@ if __name__ == "__main__":
             # Engine parameters.
             dt=0.004,
             ctrl_dt=0.02,
-            zero_offset_std=math.radians(5.0),
+            zero_offset_std=math.radians(3.0),
+            zero_offset_mag=math.radians(3.0),
             # Simulation parameters.
             iterations=8,
             ls_iterations=8,

--- a/examples/walking.py
+++ b/examples/walking.py
@@ -301,7 +301,7 @@ class WalkingConfig(ksim.PPOConfig):
         help="The acceleration for the angular velocity command, in rad/s^2.",
     )
     angular_velocity_range: tuple[float, float] = xax.field(
-        value=(-0.2, 0.2),
+        value=(0.0, 0.2),
         help="The range for the angular velocity command.",
     )
     angular_velocity_zero_prob: float = xax.field(
@@ -534,7 +534,7 @@ class WalkingTask(ksim.PPOTask[Config], Generic[Config]):
                 force_obs="feet_force",
                 ctrl_dt=self.config.ctrl_dt,
                 expected_weight=10.0,
-                scale=-1e-1,
+                scale=1e-1,
             ),
             "motionless_at_rest": ksim.MotionlessAtRestPenalty(scale=1e-2),
         }
@@ -779,6 +779,7 @@ if __name__ == "__main__":
             # Engine parameters.
             dt=0.004,
             ctrl_dt=0.02,
+            zero_offset_std=math.radians(5.0),
             # Simulation parameters.
             iterations=8,
             ls_iterations=8,

--- a/ksim/actuators.py
+++ b/ksim/actuators.py
@@ -153,8 +153,10 @@ class PositionActuators(Actuators):
         scaled = action * self.action_scale
 
         pos_rng, tor_rng = jax.random.split(rng)
-        current_pos = qpos[7:]  # First 7 are always root pos.
-        current_vel = qvel[6:]  # First 6 are always root vel.
+
+        # Calling function removes root position and velocity.
+        current_pos = qpos
+        current_vel = qvel
 
         # Add position and velocity noise
         target_position = self.action_noise.add_noise(scaled, curriculum_level, pos_rng)
@@ -199,8 +201,9 @@ class PositionVelocityActuator(PositionActuators):
         """Get the control signal from the (position and velocity) action vector."""
         pos_rng, vel_rng, tor_rng = jax.random.split(rng, 3)
 
-        current_pos = qpos[7:]  # First 7 are always root pos.
-        current_vel = qvel[6:]  # First 6 are always root vel.
+        # Calling function removes root position and velocity.
+        current_pos = qpos
+        current_vel = qvel
 
         # Extract position and velocity targets
         target_position = action[: len(current_pos)]

--- a/ksim/actuators.py
+++ b/ksim/actuators.py
@@ -6,7 +6,6 @@ __all__ = [
     "TorqueActuators",
     "PositionActuators",
     "PositionVelocityActuator",
-    "BiasedPositionActuators",
 ]
 
 import logging

--- a/ksim/actuators.py
+++ b/ksim/actuators.py
@@ -11,14 +11,13 @@ __all__ = [
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TypedDict
 
 import chex
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PRNGKeyArray, PyTree
 
-from ksim.noise import Noise, NoNoise, RandomVariable, UniformRandomVariable
+from ksim.noise import Noise, NoNoise
 from ksim.types import Metadata, PhysicsModel
 from ksim.utils.mujoco import get_ctrl_data_idx_by_name
 
@@ -222,74 +221,3 @@ class PositionVelocityActuator(PositionActuators):
             -self.ctrl_clip,
             self.ctrl_clip,
         )
-
-
-class TorqueBias(TypedDict):
-    action: Array
-    torque: Array
-
-
-class BiasedPositionActuators(PositionActuators, StatefulActuators):
-    """Adds some random bias to the position action to simulate imperfect actuators."""
-
-    def __init__(
-        self,
-        physics_model: PhysicsModel,
-        metadata: Metadata,
-        action_bias: RandomVariable | float,
-        torque_bias: RandomVariable | float,
-        action_noise: Noise | None = None,
-        torque_noise: Noise | None = None,
-        action_scale: float = 1.0,
-    ) -> None:
-        super().__init__(
-            physics_model=physics_model,
-            metadata=metadata,
-            action_noise=action_noise,
-            torque_noise=torque_noise,
-            action_scale=action_scale,
-        )
-
-        if not isinstance(action_bias, RandomVariable):
-            action_bias = UniformRandomVariable(mean=0.0, mag=action_bias)
-        if not isinstance(torque_bias, RandomVariable):
-            torque_bias = UniformRandomVariable(mean=0.0, mag=torque_bias)
-        self.action_bias = action_bias
-        self.torque_bias = torque_bias
-
-    def get_stateful_ctrl(
-        self,
-        action: Array,
-        qpos: Array,
-        qvel: Array,
-        curriculum_level: Array,
-        actuator_state: TorqueBias,
-        rng: PRNGKeyArray,
-    ) -> tuple[Array, TorqueBias]:
-        """Get the control signal from the (position) action vector."""
-        action_bias = actuator_state["action"]
-        torque_bias = actuator_state["torque"]
-
-        scaled = action * self.action_scale
-
-        pos_rng, tor_rng = jax.random.split(rng)
-        current_pos = qpos[7:]  # First 7 are always root pos.
-        current_vel = qvel[6:]  # First 6 are always root vel.
-
-        # Add position and velocity noise
-        target_position = self.action_noise.add_noise(scaled, curriculum_level, pos_rng) + action_bias
-        target_velocity = jnp.zeros_like(action)
-
-        pos_delta = target_position - current_pos
-        vel_delta = target_velocity - current_vel
-
-        ctrl = self.kps * pos_delta + self.kds * vel_delta
-        ctrl = self.torque_noise.add_noise(ctrl, curriculum_level, tor_rng) + torque_bias
-        return jnp.clip(ctrl, -self.ctrl_clip, self.ctrl_clip), actuator_state
-
-    def get_initial_state(self, qpos: Array, qvel: Array, rng: PRNGKeyArray) -> TorqueBias:
-        shape = qpos[7:].shape
-        return {
-            "action": self.action_bias.get_random_variable(shape, rng),
-            "torque": self.torque_bias.get_random_variable(shape, rng),
-        }

--- a/ksim/engine.py
+++ b/ksim/engine.py
@@ -296,8 +296,8 @@ class MjxEngine(PhysicsEngine):
                 if isinstance(self.actuators, StatefulActuators):
                     torques, actuator_state = self.actuators.get_stateful_ctrl(
                         action=ctrl,
-                        qpos=carry_data.qpos - physics_state.zero_offset,
-                        qvel=carry_data.qvel,
+                        qpos=carry_data.qpos[..., 7:] - physics_state.zero_offset,
+                        qvel=carry_data.qvel[..., 6:],
                         curriculum_level=curriculum_level,
                         actuator_state=prev_actuator_state,
                         rng=rng_update,
@@ -305,8 +305,8 @@ class MjxEngine(PhysicsEngine):
                 else:
                     torques = self.actuators.get_ctrl(
                         action=ctrl,
-                        qpos=carry_data.qpos - physics_state.zero_offset,
-                        qvel=carry_data.qvel,
+                        qpos=carry_data.qpos[..., 7:] - physics_state.zero_offset,
+                        qvel=carry_data.qvel[..., 6:],
                         curriculum_level=curriculum_level,
                         rng=rng_update,
                     )
@@ -441,8 +441,8 @@ class MujocoEngine(PhysicsEngine):
                 if isinstance(self.actuators, StatefulActuators):
                     torques, actuator_state = self.actuators.get_stateful_ctrl(
                         action=ctrl,
-                        qpos=mj_data.qpos - physics_state.zero_offset,
-                        qvel=mj_data.qvel,
+                        qpos=mj_data.qpos[..., 7:] - physics_state.zero_offset,
+                        qvel=mj_data.qvel[..., 6:],
                         curriculum_level=curriculum_level,
                         actuator_state=actuator_state,
                         rng=rng_update,
@@ -450,8 +450,8 @@ class MujocoEngine(PhysicsEngine):
                 else:
                     torques = self.actuators.get_ctrl(
                         action=ctrl,
-                        qpos=mj_data.qpos - physics_state.zero_offset,
-                        qvel=mj_data.qvel,
+                        qpos=mj_data.qpos[..., 7:] - physics_state.zero_offset,
+                        qvel=mj_data.qvel[..., 6:],
                         curriculum_level=curriculum_level,
                         rng=rng_update,
                     )

--- a/ksim/engine.py
+++ b/ksim/engine.py
@@ -90,8 +90,6 @@ class EngineConfig:
             raise ValueError("`min_action_latency` must be less than or equal to `max_action_latency`")
         if max_action_latency > self.ctrl_dt:
             logger.warning("`max_action_latency=%f` is greater than `ctrl_dt=%f`", max_action_latency, self.ctrl_dt)
-        if self.zero_offset_std < 0:
-            raise ValueError("`zero_offset_std` must be non-negative")
         if (remainder := (self.ctrl_dt - round(self.ctrl_dt / self.dt) * self.dt)) > 1e-6:
             logger.warning("`ctrl_dt=%f` is not a multiple of `dt=%f` (remainder=%f)", self.ctrl_dt, self.dt, remainder)
 

--- a/ksim/observation.py
+++ b/ksim/observation.py
@@ -221,8 +221,8 @@ class BaseAngularVelocityObservation(Observation):
 class JointPositionObservation(Observation):
     def observe(self, state: ObservationInput, curriculum_level: Array, rng: PRNGKeyArray) -> Array:
         qpos = state.physics_state.data.qpos[7:]
-        offset = state.physics_state.zero_offset
-        return qpos - offset  # (N,)
+        zero_offset = state.physics_state.zero_offset
+        return qpos - zero_offset  # (N,)
 
 
 @attrs.define(frozen=True, kw_only=True)

--- a/ksim/observation.py
+++ b/ksim/observation.py
@@ -11,7 +11,6 @@ __all__ = [
     "JointPositionObservation",
     "JointVelocityObservation",
     "DelayedJointPositionObservation",
-    "BiasedJointPositionObservation",
     "DelayedJointVelocityObservation",
     "CenterOfMassInertiaObservation",
     "CenterOfMassVelocityObservation",
@@ -221,7 +220,9 @@ class BaseAngularVelocityObservation(Observation):
 @attrs.define(frozen=True, kw_only=True)
 class JointPositionObservation(Observation):
     def observe(self, state: ObservationInput, curriculum_level: Array, rng: PRNGKeyArray) -> Array:
-        return state.physics_state.data.qpos[7:]  # (N,)
+        qpos = state.physics_state.data.qpos[7:]
+        offset = state.physics_state.zero_offset
+        return qpos - offset  # (N,)
 
 
 @attrs.define(frozen=True, kw_only=True)
@@ -241,37 +242,13 @@ class DelayedJointPositionObservation(StatefulObservation):
 
         carry_buffer = state.obs_carry
 
-        delayed_qpos = carry_buffer[0]
+        zero_offset = state.physics_state.zero_offset
+        delayed_qpos = carry_buffer[0] - zero_offset
 
         new_carry = jnp.roll(carry_buffer, -1, axis=0)
         new_carry = new_carry.at[-1].set(current_qpos)
 
         return delayed_qpos, new_carry
-
-
-@attrs.define(frozen=True, kw_only=True)
-class BiasedJointPositionObservation(StatefulObservation):
-    """Observes joint positions with an added bias in addition to noise."""
-
-    bias_range: float = attrs.field(default=0.0)
-
-    def initial_carry(self, physics_state: PhysicsState, rng: PRNGKeyArray) -> Array:
-        num_joints = physics_state.data.qpos[7:].shape[0]  # Skip first 7 DoF (base pose)
-        bias = jax.random.uniform(rng, shape=(num_joints,), minval=-self.bias_range, maxval=self.bias_range)
-        return bias
-
-    def observe_stateful(
-        self,
-        state: ObservationInput,
-        curriculum_level: Array,
-        rng: PRNGKeyArray,
-    ) -> tuple[Array, Array]:
-        bias: Array = state.obs_carry
-        joint_pos = state.physics_state.data.qpos[7:]  # Skip first 7 DoF (base pose)
-
-        biased_pos = joint_pos + bias
-
-        return biased_pos, bias
 
 
 @attrs.define(frozen=True, kw_only=True)
@@ -765,6 +742,6 @@ class ActPosObservation(Observation):
         )
 
     def observe(self, state: ObservationInput, curriculum_level: Array, rng: PRNGKeyArray) -> Array:
-        action_val = state.physics_state.most_recent_action[self.ctrl_idx]
+        action_val = state.physics_state.last_ctrl[self.ctrl_idx]
         joint_pos = state.physics_state.data.qpos[self.qpos_idx]
         return jnp.array([action_val, joint_pos])

--- a/ksim/types.py
+++ b/ksim/types.py
@@ -23,11 +23,7 @@ import jax.numpy as jnp
 import mujoco
 import xax
 from jaxtyping import Array, PyTree
-from kscale.web.gen.api import (
-    ActuatorMetadataOutput,
-    JointMetadataOutput,
-    RobotURDFMetadataOutput,
-)
+from kscale.web.gen.api import ActuatorMetadataOutput, JointMetadataOutput, RobotURDFMetadataOutput
 from mujoco import mjx
 
 PhysicsData: TypeAlias = mjx.Data | mujoco.MjData
@@ -39,11 +35,12 @@ PhysicsModel: TypeAlias = mjx.Model | mujoco.MjModel
 class PhysicsState:
     """Everything you need for the engine to take an action and step physics."""
 
-    most_recent_action: Array
+    last_ctrl: Array
     data: PhysicsData
     event_states: xax.FrozenDict[str, PyTree]
     actuator_state: PyTree
     action_latency: Array
+    zero_offset: Array
 
 
 @jax.tree_util.register_dataclass


### PR DESCRIPTION
proper zero offset implementation, where the observation offset matches the engine offset

for reading qpos: if current "true" `qpos` is 0 but the zero position is set to `0.1`, then on the real robot, we will read `qpos` as `-0.1`. similarly, if the policy outputs a target position of 0, then on the real robot, we will actually go to the target position of `0.1`